### PR TITLE
Add Dispatcher::dispatchRequest

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -6,6 +6,7 @@ use FastRoute;
 use FastRoute\Dispatcher\GroupCountBased as GroupCountBasedDispatcher;
 use League\Dic\ContainerAwareInterface;
 use League\Dic\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 class Dispatcher extends GroupCountBasedDispatcher
 {
@@ -27,8 +28,9 @@ class Dispatcher extends GroupCountBasedDispatcher
     /**
      * Constructor
      *
-     * @param array $routes
-     * @param array $data
+     * @param ContainerInterface $container
+     * @param array              $routes
+     * @param array              $data
      */
     public function __construct(ContainerInterface $container, array $routes, array $data)
     {
@@ -67,6 +69,18 @@ class Dispatcher extends GroupCountBasedDispatcher
         }
 
         return $response;
+    }
+
+    /**
+     * Match and dispatch a route from an existing request object
+     *
+     * @param Request $request
+     *
+     * @return \League\Http\ResponseInterface
+     */
+    public function dispatchRequest(Request $request)
+    {
+        return $this->dispatch($request->getMethod(), $request->getPathInfo());
     }
 
     /**


### PR DESCRIPTION
Since `symfony/http-foundation` is already in use throughout the package, this adds a shortcut method on the dispatcher to dispatch from an existing request object. As most applications and micro-applications will have one somewhere, this makes the integration of the package easier in an existing project.

I tried to add a test but it seems the namespaces are wrong in some places cause it failed everywhere:

```
$ phpunit

EPHP Fatal error:  Interface 'League\Dic\ContainerAwareInterface' not found in /Users/anahkiasen/Sites/_github/route/src/Strategy/AbstractStrategy.php on line 11
```