### PR TITLE
Allow route arguments to be passed in to controller of MethodArgumentStrategy

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -96,6 +96,11 @@ class Dispatcher extends GroupCountBasedDispatcher
             $controller = explode('::', $handler);
         }
 
+        // Check if handler is a registered callable alias.
+        if (is_string($handler) && $this->container->isRegisteredCallable($handler)) {
+            $controller = $handler;
+        }
+
         // if controller method wasn't specified, throw exception.
         if (! $controller) {
             throw new \RuntimeException('A class method must be provided as a controller. ClassName::methodName');

--- a/src/Strategy/MethodArgumentStrategy.php
+++ b/src/Strategy/MethodArgumentStrategy.php
@@ -20,7 +20,7 @@ class MethodArgumentStrategy extends AbstractStrategy implements StrategyInterfa
             ];
         }
 
-        $response = $this->container->call($controller);
+        $response = $this->container->call($controller, $vars);
 
         return $this->determineResponse($response);
     }


### PR DESCRIPTION
The `MethodArgumentStrategy` allows you to inject anything into the controller method.

```php
class HelloController
{
    protected $repository;

    public function __construct(Repository $repository)
    {
        $this->repository = $repository;
    }

    public function index(Validator $validator, Request $request)
    {
         $filter = $request->get('filter');

         $validator->validate(compact('filter'));
         ...
    }
}
```

But with this simple change you can do this:

```php
class HelloController
{
    protected $repository;

    public function __construct(Repository $repository)
    {
        $this->repository = $repository;
    }

    public function show(ViewFactory $view, $name)
    {
         $user = $this->repository->findByName($name);
         return $view->render('user/show.twig', compact('user'));
    }
}
```

```php
$router = new League\Route\RouteCollection();
$router->setStrategy(new MethodArgumentStrategy());

$router->get('/user/{name}', 'UserController::show');

$response = $router->getDispatcher()->dispatch('GET', '/users/username');
```

