### PR TITLE
Passing vars to container call method

### DIFF
--- a/src/Strategy/MethodArgumentStrategy.php
+++ b/src/Strategy/MethodArgumentStrategy.php
@@ -20,7 +20,7 @@ class MethodArgumentStrategy extends AbstractStrategy implements StrategyInterfa
             ];
         }
 
-        $response = $this->container->call($controller);
+        $response = $this->container->call($controller, $vars);
 
         return $this->determineResponse($response);
     }


### PR DESCRIPTION
If you are using MethodArgumentStrategy, it's impossible to use wildcard routes.
Let's say we have this route

```
$router->get('/test/{id:number}/{test:word}', function( $id, $test, Request $request) {
    //code
});
```

We are going to get this exception 
```
RuntimeException: Cannot resolve argument [id], it should be provided within an array of arguments passed to [League\Container\Container::call], have a default value or be type hinted
```

Sorry, if I'm just being stupid and could not find another way to make it working,  but to me it seems like you forgot to pass $vars to container call method.
