### PR TITLE
Added new method ->addPatternMatcher to RouteCollection.

### DIFF
--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -28,6 +28,12 @@ class RouteCollection extends RouteCollector
      */
     protected $routes = [];
 
+    protected $patternMatchers = [
+        '/{(.+?):number}/'        => '{$1:[0-9]+}',
+        '/{(.+?):word}/'          => '{$1:[a-zA-Z]+}',
+        '/{(.+?):alphanum_dash}/' => '{$1:[a-zA-Z0-9-_]+}'
+    ];
+
     /**
      * Constructor
      *
@@ -188,6 +194,21 @@ class RouteCollection extends RouteCollector
     }
 
     /**
+     * Add a convenient pattern matcher to the internal array for use with all routes.
+     *
+     * @param string $keyWord
+     * @param string $regex
+     */
+    public function addPatternMatcher($keyWord, $regex)
+    {
+        // Since the user is passing in a human-readable word, we convert that to the appropriate regex
+        $pattern = '/{(.+?):' . $keyWord . '}/';
+        $regex = '{$1:' . $regex . '}';
+
+        $this->patternMatchers[$pattern] = $regex;
+    }
+
+    /**
      * Convenience method to convert pre-defined key words in to regex strings
      *
      * @param  string $route
@@ -195,12 +216,6 @@ class RouteCollection extends RouteCollector
      */
     protected function parseRouteString($route)
     {
-        $wildcards = [
-            '/{(.+?):number}/'        => '{$1:[0-9]+}',
-            '/{(.+?):word}/'          => '{$1:[a-zA-Z]+}',
-            '/{(.+?):alphanum_dash}/' => '{$1:[a-zA-Z0-9-_]+}'
-        ];
-
-        return preg_replace(array_keys($wildcards), array_values($wildcards), $route);
+        return preg_replace(array_keys($this->patternMatchers), array_values($this->patternMatchers), $route);
     }
 }

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -151,4 +151,21 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('League\Route\Dispatcher', $router->getDispatcher());
         $this->assertInstanceOf('FastRoute\Dispatcher\GroupCountBased', $router->getDispatcher());
     }
+
+    /**
+     * Asserts that appropriately configured regex strings are added to patternMatchers.
+     *
+     * @return void
+     */
+    public function testNewPatternMatchesCanBeAddedAtRuntime()
+    {
+        $router = new RouteCollection;
+
+        $router->addPatternMatcher('mockMatcher', '[a-zA-Z]');
+
+        $matchers = $this->getObjectAttribute($router, "patternMatchers");
+
+        $this->assertArrayHasKey('/{(.+?):mockMatcher}/', $matchers);
+        $this->assertEquals('{$1:[a-zA-Z]}', $matchers['/{(.+?):mockMatcher}/']);
+    }
 }


### PR DESCRIPTION
This new method allows users to add their own "convenience" type restrictions to the routecollection at runtime. I've submitted a separate PR against github pages for the updated documentation.


Refactored all convience methods into an internal protected property that can be added to with the new method.
Updated parseRouteString to use this new internal array.