### PR TITLE
Added named routes (@routeName/my/route) and URL Generator

### DIFF
--- a/src/RouteParser.php
+++ b/src/RouteParser.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace League\Route;
+
+use FastRoute\RouteParser as IRouteParser;
+use FastRoute\RouteParser\Std;
+
+/**
+ * Parses routes of the following form:
+ *
+ * "/user/{name}/{id:[0-9]+}"
+ */
+class RouteParser extends Std implements IRouteParser
+{
+    /**
+     * Regex to find the route alias
+     */
+    const ALIAS_REGEX = '/^(@[a-zA-Z0-9-_\.]+)/';
+    
+    /**
+     * Parses the string into an array of segments
+     *
+     * @param string $route
+     * @return array
+     */
+    public function parse($route)
+    {
+        
+        //Remove possible name in route
+        $route = preg_replace(self::ALIAS_REGEX, '', $route);
+        
+        return parent::parse($route);
+    }
+}

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace League\Route;
+
+use League\Route\RouteCollection;
+use FastRoute\RouteParser as IRouteParser;
+use FastRoute\RouteParser\Std as StdRouteParser;
+
+/**
+ * Generates an URL from a RouteCollection
+ *
+ * @author Sonia Marquette <contact@nebulousweb.com>
+ */
+class UrlGenerator
+{
+
+    /**
+     * Route collection to use
+     *
+     * @var RouteCollection
+     */
+    protected $routes;
+
+    /**
+     * Route Parser to use
+     * @var RouteParser
+     */
+    protected $parser;
+
+    /**
+     * The base to which urls are appended
+     * @var string
+     */
+    protected $baseUrl = '';
+
+    public function __construct(RouteCollection $routes, IRouteParser $parser = null)
+    {
+        $this->routes = $routes;
+        $this->parser = is_null($parser) ? new StdRouteParser : $parser;
+    }
+
+    /**
+     * Set the base url to use when generating new urls
+     * @param string $baseUrl
+     * @return \League\Route\UrlGenerator
+     */
+    public function setBaseUrl($baseUrl)
+    {
+        $this->baseUrl = $baseUrl;
+        return $this;
+    }
+
+    /**
+     * Generates an url using a registered route
+     *
+     * @param string $name Route Alias
+     * @param array $params
+     * @return string
+     * @throws \OutOfBoundsException
+     * @throws \InvalidArgumentException
+     */
+    public function generate($name, $params = array(), $include_base = true)
+    {
+        //Ensure the names starts with @
+        $alias = strpos($name, '@') === false ? '@' . $name : $name;
+
+        $routes = $this->routes->getNamedRoutes();
+
+        //Verify the route exists
+        if (!isset($routes[$alias])) {
+            throw new \OutOfBoundsException(sprintf('The named route %s does not exist.', $alias));
+        }
+
+        //Parse route into array of parameters to build the new url
+        $parsed_route = $this->parser->parse($routes[$alias]);
+        $url = '';
+
+        foreach ($parsed_route as $part) {
+            if (is_string($part)) {
+                $url .= $part;
+            } elseif (is_array($part) && isset($params[$part[0]]) && preg_match('#' . $part[1] . '#', $params[$part[0]])) {
+                $url .= $params[$part[0]];
+            } elseif (isset($params[$part[0]])) {
+                throw new \InvalidArgumentException(sprintf('Invalid value %s for parameter %s for route %s. Does not match the pattern: %s', $params[$part[0]], $part[0], $alias, $part[1]));
+            } else {
+                throw new \InvalidArgumentException(sprintf('Missing parameter %s for route %s.', $part[0], $alias));
+            }
+        }
+
+        return ($include_base && !empty($this->baseUrl) ? rtrim($this->baseUrl, '/') . '/' : '' ) . ltrim($url, '/');
+    }
+}

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -168,4 +168,22 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('/{(.+?):mockMatcher}/', $matchers);
         $this->assertEquals('{$1:[a-zA-Z]}', $matchers['/{(.+?):mockMatcher}/']);
     }
+    
+    /**
+     * Asserts named routes are put in namedRoute array
+     *
+     * @return void
+     */
+    public function testNamedRoutesAreProperlyHandled()
+    {
+        $router = new RouteCollection;
+        $router->addRoute('GET', 'noname', function() {
+        });
+        $router->addRoute('GET', '@name/named-route', function() {
+        });
+        $router->addRoute('GET', '@another-name/another-named-route', function() {
+        });
+        
+        $this->assertCount(2, $router->getNamedRoutes());
+    }
 }

--- a/tests/RouteParserTest.php
+++ b/tests/RouteParserTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace League\Route\Test;
+
+use League\Route\RouteParser;
+
+class RouteParserTest extends \PHPUnit_Framework_TestCase
+{
+    
+    /**
+     * Asserts that the @ sign is correctly added when missing
+     */
+    public function testNamedRouteAreHandledTheSameAsNotNamedRoute()
+    {
+        $parser = new RouteParser;
+        
+        $this->assertEquals($parser->parse('@bundle.named_route/my-route'), $parser->parse('/my-route'));
+    }
+}

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace League\Route\Test;
+
+use League\Route\RouteCollection;
+use League\Route\UrlGenerator;
+
+class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    
+    /**
+     * Asserts that the @ sign is correctly added when missing
+     */
+    public function testMissingAtSign()
+    {
+        $routes = new RouteCollection;
+        $routes->addRoute('GET', '@namedRoute/test', function() {
+        });
+        $generator = new UrlGenerator($routes);
+        
+        $this->assertEquals($generator->generate('@namedRoute'), $generator->generate('namedRoute'));
+    }
+    
+    /**
+     * Asserts that named routes are correctly generated
+     */
+    public function testNamedRouteWithoutParams()
+    {
+        $routes = new RouteCollection;
+        $routes->addRoute('GET', '@namedRoute/test', function() {
+        });
+        $routes->addRoute('GET', '@namedSlashedRoute/test/', function() {
+        });
+        $generator = new UrlGenerator($routes);
+        
+        $this->assertEquals('test', $generator->generate('@namedRoute'));
+        $this->assertEquals('test/', $generator->generate('@namedSlashedRoute'));
+    }
+    
+    /**
+     * Asserts that the base url work correctly
+     */
+    public function testSetBaseUrl()
+    {
+        $routes = new RouteCollection;
+        $routes->addRoute('GET', '@namedRoute/test', function() {
+        });
+        $generator = new UrlGenerator($routes);
+        $generator->setBaseUrl('http://myfakedomain.com/');
+        
+        $this->assertEquals('http://myfakedomain.com/test', $generator->generate('@namedRoute'));
+        
+        $generator->setBaseUrl('http://myfakedomain.com');
+        $this->assertEquals('http://myfakedomain.com/test', $generator->generate('@namedRoute'));
+    }
+    
+    /**
+     * Asserts that named routes with parameters are correctly generated
+     */
+    public function testSimpleParameters()
+    {
+        $routes = new RouteCollection;
+        $routes->addRoute('GET', '@numberRoute/test/{id:number}', function() {
+        });
+        $routes->addRoute('GET', '@wordRoute/test/{name:word}', function() {
+        });
+        $routes->addRoute('GET', '@urlRoute/test/{url:alphanum_dash}', function() {
+        });
+        $routes->addRoute('GET', '@paramRoute/test/{param}', function() {
+        });
+        $routes->addRoute('GET', '@manyRoute/test/{id:number}/{name:word}', function() {
+        });
+        $generator = new UrlGenerator($routes);
+        
+        $this->assertEquals('test/1', $generator->generate('@numberRoute', array('id' => 1)));
+        $this->assertEquals('test/Name', $generator->generate('@wordRoute', array('name' => 'Name')));
+        $this->assertEquals('test/My-Url_2', $generator->generate('@urlRoute', array('url' => 'My-Url_2')));
+        $this->assertEquals('test/$%?%$', $generator->generate('@paramRoute', array('param' => '$%?%$')));
+        $this->assertEquals('test/10/test', $generator->generate('@manyRoute', array('id' => 10, 'name' => 'test')));
+    }
+    
+    /**
+     * Asserts that an exception is thrown when a parameter is missing
+     *
+     * @expectedException InvalidArgumentException
+     */
+    public function testRouteWithMissingParameter()
+    {
+        $routes = new RouteCollection;
+        $routes->addRoute('GET', '@namedRoute/test/{id:number}', function() {
+        });
+        $generator = new UrlGenerator($routes);
+        
+        $generator->generate('@namedRoute');
+    }
+    
+    /**
+     * Asserts that an exception is thrown when a parameter is invalid
+     *
+     * @expectedException InvalidArgumentException
+     */
+    public function testRouteWithInvalidParameter()
+    {
+        $routes = new RouteCollection;
+        $routes->addRoute('GET', '@namedRoute/test/{id:number}', function() {
+        });
+        $generator = new UrlGenerator($routes);
+        
+        $generator->generate('@namedRoute', array('id' => 'InvalidID'));
+        
+    }
+}


### PR DESCRIPTION
To help with routes management across an application, I have added support for named routes using the syntax @route-name/the-route.

The URL generator can then be used like this UrlGenerator->generate("route-name").