### PR TITLE
Allow using callable classes as controllers.

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -91,7 +91,7 @@ class Dispatcher extends GroupCountBasedDispatcher
         $controller = null;
 
         // figure out what the controller is
-        if (($handler instanceof Closure) || (is_string($handler) && is_callable($handler))) {
+        if (($handler instanceof Closure) || is_callable($handler)) {
             $controller = $handler;
         }
 

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -70,11 +70,15 @@ class RouteCollection extends RouteCollector
 
         // if the handler is an anonymous function, we need to store it for later use
         // by the dispatcher, otherwise we just throw the handler string at FastRoute
-        if ($handler instanceof Closure) {
+        if ($handler instanceof Closure ||
+            (is_object($handler) && is_callable($handler))
+        ) {
             $callback = $handler;
             $handler  = uniqid('league::route::', true);
 
             $this->routes[$handler]['callback'] = $callback;
+        } elseif (is_object($handler)) {
+            throw new \RuntimeException("Object controllers must be callable.");
         }
 
         $this->routes[$handler]['strategy'] = (is_null($strategy)) ? new Strategy\RequestResponseStrategy : $strategy;

--- a/tests/CallableController.php
+++ b/tests/CallableController.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * League\Route\Test\CallableController
+ */
+
+namespace League\Route\Test;
+
+/**
+ * CallableController
+ */
+class CallableController
+{
+    /**
+     * @param Symfony\Component\HttpFoundation\Request $request
+     * @param Symfony\Component\HttpFoundation\Response $response
+     */
+    public function __invoke(
+        Symfony\Component\HttpFoundation\Request $request,
+        Symfony\Component\HttpFoundation\Response $response
+    ) {
+
+    }
+}

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -168,4 +168,33 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('/{(.+?):mockMatcher}/', $matchers);
         $this->assertEquals('{$1:[a-zA-Z]}', $matchers['/{(.+?):mockMatcher}/']);
     }
+
+    public function testCallableControllers()
+    {
+        $router = new RouteCollection;
+
+        $router->get('/', new CallableController);
+
+        $routes = (new \ReflectionClass($router))->getProperty('routes');
+        $routes->setAccessible(true);
+        $routes = $routes->getValue($router);
+
+        $this->assertCount(1, $routes);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testNonCallbleObjectControllersError()
+    {
+        $router = new RouteCollection;
+
+        $router->get('/', new \stdClass);
+
+        $routes = (new \ReflectionClass($router))->getProperty('routes');
+        $routes->setAccessible(true);
+        $routes = $routes->getValue($router);
+
+        $this->assertCount(0, $routes);
+    }
 }


### PR DESCRIPTION
This change allows the use of callable objects as controllers, so that Route supports something more akin to "actions" as described by Paul Jones at http://pmjones.io/adr/