### PR TITLE
Fix example variable names

### DIFF
--- a/method-argument-strategy.md
+++ b/method-argument-strategy.md
@@ -9,7 +9,7 @@ title: MethodArgumentStrategy
 The Method Argument Strategy allows you to have your controller dependencies injected directly as arguments.
 
 ~~~ php
-$route->get('/some-route', function (SomeDependency $SomeDependency, SomeOtherDependency $someOtherDependency) {
+$router->get('/some-route', function (SomeDependency $SomeDependency, SomeOtherDependency $someOtherDependency) {
     // ...
 });
 ~~~

--- a/request-response-strategy.md
+++ b/request-response-strategy.md
@@ -12,7 +12,7 @@ The `RequestResponseStrategy` is used by default and provides the controller wit
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-$route->get('/acme/route', function (Request $request, Response $response) {
+$router->get('/acme/route', function (Request $request, Response $response) {
     // retrieve data from $request, do what you need to do and build your $content
 
     $response->setContent($content);
@@ -26,7 +26,7 @@ $route->get('/acme/route', function (Request $request, Response $response) {
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-$route->put('/user/{id}', function (Request $request, Response $response, array $args) {
+$router->put('/user/{id}', function (Request $request, Response $response, array $args) {
     $userId = $args['id'];
     $requestBody = json_decode($request->getContent(), true);
 

--- a/restful-strategy.md
+++ b/restful-strategy.md
@@ -14,7 +14,7 @@ It is expected that a `Response` object or data of a type that can be converted 
 use Symfony\Component\HttpFoundation\Request;
 
 // this route would be considered a "get all" resource
-$route->get('/acme', function (Request $request) {
+$router->get('/acme', function (Request $request) {
     // pull data from $request and do something clever
 
     return [
@@ -23,7 +23,7 @@ $route->get('/acme', function (Request $request) {
 });
 
 // this route would be considered a "get one" resource
-$route->get('/acme/{id}', function (Request $request, array $args) {
+$router->get('/acme/{id}', function (Request $request, array $args) {
     // get any required data from $request and find entity relating to $args['id']
 
     return [
@@ -43,7 +43,7 @@ For example, when creating a resource, on success we would likely return a `201 
 ~~~ php
 use League\Route\Http\JsonResponse as Response;
 
-$route->post('/acme', function (Request $request) {
+$router->post('/acme', function (Request $request) {
     // create a record from the $request body
 
     return new Response\Created([
@@ -74,7 +74,7 @@ Simply throw one of the HTTP exceptions from within your application layer and t
 ~~~ php
 use League\Route\Http\Exception\BadRequestException;
 
-$route->post('/acme', function (Request $request) {
+$router->post('/acme', function (Request $request) {
     // create a record from the $request body
 
     // if we fail to insert due to a bad request

--- a/uri-strategy.md
+++ b/uri-strategy.md
@@ -9,7 +9,7 @@ title: UriStrategy
 The URI Strategy is a simpler strategy aimed at smaller applications. It makes no assumptions about how your controller is built. The only arguments passed to your controller will be the values of any wildcard parts of your routes string if any exist. It expects a value to be returned but this can any type of `Symfony\Component\HttpFoundation\Response` based object that can be sent to the browser or a string that a response can be built from.
 
 ~~~ php
-$route->get('/hello/{name1}/{name2}', function ($name1, $name2) {
+$router->get('/hello/{name1}/{name2}', function ($name1, $name2) {
     return '<h1>Hello ' . $name1 . ' and ' . $name2 . '</h1>';
 });
 ~~~


### PR DESCRIPTION
The example variable name used in the Strategies section are inconsistent with the name used in the rest of the documentation. This patch changes all instances of `$route->` to `$router->` to match the other sections.