### PR TITLE
Create Request from globals / Fixes #35

### DIFF
--- a/src/Strategy/RequestResponseStrategy.php
+++ b/src/Strategy/RequestResponseStrategy.php
@@ -13,7 +13,7 @@ class RequestResponseStrategy extends AbstractStrategy implements StrategyInterf
     public function dispatch($controller, array $vars)
     {
         $response = $this->invokeController($controller, [
-            $this->getContainer()->get('Symfony\Component\HttpFoundation\Request'),
+            $this->getRequest(),
             $this->getContainer()->get('Symfony\Component\HttpFoundation\Response'),
             $vars
         ]);
@@ -26,5 +26,19 @@ class RequestResponseStrategy extends AbstractStrategy implements StrategyInterf
             'When using the Request -> Response Strategy your controller must ' .
             'return an instance of [Symfony\Component\HttpFoundation\Response]'
         );
+    }
+
+    /**
+     * Get Request either from the container or else create it from globals
+     * @return \Symfony\Component\HttpFoundation\Request
+     */
+    protected function getRequest()
+    {
+        if ($this->getContainer()->isRegistered('Symfony\Component\HttpFoundation\Request') ||
+            $this->getContainer()->isInServiceProvider('Symfony\Component\HttpFoundation\Request') ) {
+            return $this->getContainer()->get('Symfony\Component\HttpFoundation\Request');
+        } else {
+            return $this->getContainer()->get('Symfony\Component\HttpFoundation\Request')->createFromGlobals();
+        }
     }
 }


### PR DESCRIPTION
Get the request from the container if it was registered or in a service provider, else it will create a request object from globals.

Should I add the $vars in the attributes part of the request automatically too?