### PR TITLE
Support singleton request objects

### DIFF
--- a/src/Strategy/AbstractStrategy.php
+++ b/src/Strategy/AbstractStrategy.php
@@ -62,6 +62,7 @@ abstract class AbstractStrategy implements ContainerAwareInterface
     {
         if (
             $this->getContainer()->isRegistered('Symfony\Component\HttpFoundation\Request') ||
+            $this->getContainer()->isSingleton('Symfony\Component\HttpFoundation\Request') ||
             $this->getContainer()->isInServiceProvider('Symfony\Component\HttpFoundation\Request')
         ) {
             return $this->getContainer()->get('Symfony\Component\HttpFoundation\Request');

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -9,6 +9,7 @@ use League\Route\Strategy\MethodArgumentStrategy;
 use League\Route\Strategy\RestfulStrategy;
 use League\Route\Strategy\RequestResponseStrategy;
 use League\Route\Strategy\UriStrategy;
+use Symfony\Component\HttpFoundation\Request;
 
 class DispatcherTest extends \PHPUnit_Framework_TestCase
 {
@@ -363,6 +364,30 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
         $container = new Container();
         $container->add('Symfony\Component\HttpFoundation\Request')->withArguments([['get' => 2], ['post' => 3]]);
+        $collection = new Route\RouteCollection($container);
+        $collection->setStrategy(new RequestResponseStrategy);
+
+        $collection->get('/route', function ($request, $response) {
+            $this->assertEquals(2, $request->query->get('get'));
+            $this->assertEquals(3, $request->request->get('post'));
+            return $response;
+        });
+
+        $dispatcher = $collection->getDispatcher();
+        $response = $dispatcher->dispatch('GET', '/route');
+
+    }
+
+    /**
+     * Assert that the request object is taken from the container if it was already registered as a singleton
+     *
+     * @return void
+     */
+    public function testRequestResponseStrategyRouteSingletonRequestFromContainer()
+    {
+
+        $container = new Container();
+        $container->add('Symfony\Component\HttpFoundation\Request', new Request(['get' => 2], ['post' => 3]));
         $collection = new Route\RouteCollection($container);
         $collection->setStrategy(new RequestResponseStrategy);
 


### PR DESCRIPTION
Bugfix: Don't recreate request object, if it is already registered as a singleton.

https://github.com/alexbilbie/Proton adds a request singleton to the container, which unfortunately won't be used by league/route.