### PR TITLE
Enhancement: Assert that response is fetched from container if not set before

### DIFF
--- a/tests/Strategy/RequestResponseStrategyTest.php
+++ b/tests/Strategy/RequestResponseStrategyTest.php
@@ -123,4 +123,46 @@ class RequestResponseStrategyTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($isSameRequest);
     }
+
+    /**
+     * Asserts that strategy attempts to fetch response from container when it hasn't been set before.
+     */
+    public function testDispatchFetchesResponseFromContainerReally()
+    {
+        $request = $this->getMock('Psr\Http\Message\ServerRequestInterface');
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+
+        $container = $this->getMock('Interop\Container\ContainerInterface');
+
+        $container
+            ->expects($this->any())
+            ->method('has')
+            ->with('Psr\Http\Message\ResponseInterface')
+            ->willReturn(true)
+        ;
+
+        $container
+            ->expects($this->any())
+            ->method('get')
+            ->with('Psr\Http\Message\ResponseInterface')
+            ->willReturn($response)
+        ;
+
+        $isSameResponse = false;
+
+        $strategy = new RequestResponseStrategy();
+
+        $strategy->setRequest($request);
+        $strategy->setContainer($container);
+
+        $strategy->dispatch(function ($actualRequest, $actualResponse) use ($response, &$isSameResponse) {
+            if ($actualResponse === $response) {
+                $isSameResponse = true;
+            }
+
+            return $actualResponse;
+        }, []);
+
+        $this->assertTrue($isSameResponse);
+    }
 }


### PR DESCRIPTION
:exclamation: Blocked by #78.

This PR

* [x] asserts that the `RequestResponseStragegy` will attempt to fetch the response object from the container if a response object hasn't been set before

Follows #77.