### PR TITLE
Fix: Add missing $ before parameter name in docblock

### DIFF
--- a/src/RouteConditionTrait.php
+++ b/src/RouteConditionTrait.php
@@ -56,7 +56,7 @@ trait RouteConditionTrait
     /**
      * Set the name.
      *
-     * @param string name
+     * @param string $name
      *
      * @return \League\Route\Route
      */


### PR DESCRIPTION
This PR

* [x] adds the required :dollar: before a parameter name in a docblock