### PR TITLE
Fix: Use a more specific type in docblocks

### DIFF
--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -27,12 +27,12 @@ class RouteCollection extends RouteCollector implements StrategyAwareInterface, 
     protected $container;
 
     /**
-     * @var array
+     * @var \League\Route\Route[]
      */
     protected $routes = [];
 
     /**
-     * @var array
+     * @var \League\Route\Route[]
      */
     protected $namedRoutes = [];
 


### PR DESCRIPTION
This PR

* [x] uses a more specific type in instance property docblocks