### PR TITLE
Fix: Rename test

### DIFF
--- a/tests/Strategy/RequestResponseStrategyTest.php
+++ b/tests/Strategy/RequestResponseStrategyTest.php
@@ -85,7 +85,7 @@ class RequestResponseStrategyTest extends \PHPUnit_Framework_TestCase
     /**
      * Asserts that strategy attempts to fetch request from container when it hasn't been set before.
      */
-    public function testDispatchFetchesResponseFromContainer()
+    public function testDispatchFetchesRequestFromContainer()
     {
         $request = $this->getMock('Psr\Http\Message\ServerRequestInterface');
         $response = $this->getMock('Psr\Http\Message\ResponseInterface');


### PR DESCRIPTION
This PR

* [x] renames a test

Related to #78.
Blocks #78.

:information_desk_person: The test actually asserts that the request is fetched from the container, while in #78 I attempted to assert that the response is fetched, that's why I messed up the rebase (not :eyes: closely enough).