### PR TITLE
Fix: Test name

### DIFF
--- a/tests/Strategy/RequestResponseStrategyTest.php
+++ b/tests/Strategy/RequestResponseStrategyTest.php
@@ -127,7 +127,7 @@ class RequestResponseStrategyTest extends \PHPUnit_Framework_TestCase
     /**
      * Asserts that strategy attempts to fetch response from container when it hasn't been set before.
      */
-    public function testDispatchFetchesResponseFromContainerReally()
+    public function testDispatchFetchesResponseFromContainer()
     {
         $request = $this->getMock('Psr\Http\Message\ServerRequestInterface');
         $response = $this->getMock('Psr\Http\Message\ResponseInterface');


### PR DESCRIPTION
This PR

* [x] fixes a test name

Follows #78.

:person_with_pouting_face: Actually wanted to rebase #78 after #92 was merged (test method names would have conflicted).