### PR TITLE
Add support to quantifiers on wildcards

### DIFF
--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -45,10 +45,10 @@ class RouteCollection extends RouteCollector implements StrategyAwareInterface, 
      * @var array
      */
     protected $patternMatchers = [
-        '/{(.+?):number}/'        => '{$1:[0-9]+}',
-        '/{(.+?):word}/'          => '{$1:[a-zA-Z]+}',
-        '/{(.+?):alphanum_dash}/' => '{$1:[a-zA-Z0-9-_]+}',
-        '/{(.+?):slug}/'          => '{$1:[a-z0-9-]+}'
+        '/{(.+?):number(\+|{[0-9,]+})?}/'        => '{$1:[0-9]$2}',
+        '/{(.+?):word(\+|{[0-9,]+})?}/'          => '{$1:[a-zA-Z]$2}',
+        '/{(.+?):alphanum_dash(\+|{[0-9,]+})?}/' => '{$1:[a-zA-Z0-9-_]$2}',
+        '/{(.+?):slug(\+|{[0-9,]+})?}/'          => '{$1:[a-z0-9-]$2}'
     ];
 
     /**
@@ -225,8 +225,8 @@ class RouteCollection extends RouteCollector implements StrategyAwareInterface, 
      */
     public function addPatternMatcher($alias, $regex)
     {
-        $pattern = '/{(.+?):' . $alias . '}/';
-        $regex   = '{$1:' . $regex . '}';
+        $pattern = '/{(.+?):' . $alias . '(\+|{[0-9,]+})?}/';
+        $regex   = '{$1:' . $regex . '$2}';
 
         $this->patternMatchers[$pattern] = $regex;
     }

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -87,8 +87,8 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
 
         $matchers = $this->getObjectAttribute($router, 'patternMatchers');
 
-        $this->assertArrayHasKey('/{(.+?):mockMatcher}/', $matchers);
-        $this->assertEquals('{$1:[a-zA-Z]}', $matchers['/{(.+?):mockMatcher}/']);
+        $this->assertArrayHasKey('/{(.+?):mockMatcher(\+|{[0-9,]+})?}/', $matchers);
+        $this->assertEquals('{$1:[a-zA-Z]$2}', $matchers['/{(.+?):mockMatcher(\+|{[0-9,]+})?}/']);
     }
 
     /**


### PR DESCRIPTION
The wildcards `number` and `word` for example, does not support quantifiers, all have by default the `+` as match quantifier. Now is supported all the regex quantifiers but `*` and `?`. See more about quantifiers [here](https://en.wikipedia.org/wiki/Regular_expression#Basic_concepts).