### PR TITLE
Don't need branch alises here

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,9 +44,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.x-dev",
-            "2.x": "2.x-dev",
-            "1.x": "1.x-dev"
+            "dev-master": "3.x-dev"
         }
     }
 }


### PR DESCRIPTION
Aliases are for when the branch name doesn't match the version, but for 1.x, you're just aliasing it, to itself.