### PR TITLE
Have strategies decorate exceptions themselves

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -2,6 +2,7 @@
 
 namespace League\Route;
 
+use Exception;
 use FastRoute\Dispatcher as FastRoute;
 use FastRoute\Dispatcher\GroupCountBased as GroupCountBasedDispatcher;
 use League\Route\Http\Exception\MethodNotAllowedException;
@@ -64,16 +65,8 @@ class Dispatcher extends GroupCountBasedDispatcher implements StrategyAwareInter
      */
     protected function handleNotFound()
     {
-        $middleware = function (ServerRequestInterface $request, ResponseInterface $response) {
-            $exception = new NotFoundException;
-
-            if ($this->getStrategy() instanceof JsonStrategy) {
-                return $exception->buildJsonResponse($response);
-            }
-
-            throw $exception;
-        };
-
+        $exception  = new NotFoundException;
+        $middleware = $this->getStrategy()->getNotFoundDecorator($exception);
         return (new ExecutionChain)->middleware($middleware);
     }
 
@@ -86,16 +79,8 @@ class Dispatcher extends GroupCountBasedDispatcher implements StrategyAwareInter
      */
     protected function handleNotAllowed(array $allowed)
     {
-        $middleware = function (ServerRequestInterface $request, ResponseInterface $response) use ($allowed) {
-            $exception = new MethodNotAllowedException($allowed);
-
-            if ($this->getStrategy() instanceof JsonStrategy) {
-                return $exception->buildJsonResponse($response);
-            }
-
-            throw $exception;
-        };
-
+        $exception  = new MethodNotAllowedException($allowed);
+        $middleware = $this->getStrategy()->getMethodNotAllowedDecorator($exception);
         return (new ExecutionChain)->middleware($middleware);
     }
 }

--- a/src/Strategy/ApplicationStrategy.php
+++ b/src/Strategy/ApplicationStrategy.php
@@ -2,6 +2,9 @@
 
 namespace League\Route\Strategy;
 
+use \Exception;
+use League\Route\Http\Exception\MethodNotAllowedException;
+use League\Route\Http\Exception\NotFoundException;
 use League\Route\Middleware\ExecutionChain;
 use League\Route\Route;
 use RuntimeException;
@@ -41,5 +44,29 @@ class ApplicationStrategy implements StrategyInterface
         }
 
         return $execChain;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNotFoundDecorator(NotFoundException $exception)
+    {
+        throw $exception;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMethodNotAllowedDecorator(MethodNotAllowedException $exception)
+    {
+        throw $exception;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExceptionDecorator(Exception $exception)
+    {
+        throw $exception;
     }
 }

--- a/src/Strategy/StrategyInterface.php
+++ b/src/Strategy/StrategyInterface.php
@@ -2,6 +2,9 @@
 
 namespace League\Route\Strategy;
 
+use \Exception;
+use League\Route\Http\Exception\MethodNotAllowedException;
+use League\Route\Http\Exception\NotFoundException;
 use League\Route\Route;
 
 interface StrategyInterface
@@ -17,4 +20,73 @@ interface StrategyInterface
      * @return \League\Route\Middleware\ExecutionChain
      */
     public function getExecutionChain(Route $route, array $vars);
+
+    /**
+     * Taskied with handling a not found exception, expects a
+     * PSR-7 compatible middleware/callable to be returned
+     * or for the exception to simply be thrown.
+     *
+     * ```
+     * throw $exception;
+     * ```
+     * or
+     * ```
+     * return function ($request, $response) {
+     *     // ...
+     *     // it is recommended to return the response when decorating an exception
+     *     return $response;
+     * }
+     * ```
+     *
+     * @param \League\Route\Http\Exception\NotFoundException $exception
+     *
+     * @return callable
+     */
+    public function getNotFoundDecorator(NotFoundException $exception);
+
+    /**
+     * Taskied with handling a not allowed exception, expects a
+     * PSR-7 compatible middleware/callable to be returned
+     * or for the exception to simply be thrown.
+     *
+     * ```
+     * throw $exception;
+     * ```
+     * or
+     * ```
+     * return function ($request, $response) {
+     *     // ...
+     *     // it is recommended to return the response when decorating an exception
+     *     return $response;
+     * }
+     * ```
+     *
+     * @param \League\Route\Http\Exception\MethodNotAllowedException $exception
+     *
+     * @return callable
+     */
+    public function getMethodNotAllowedDecorator(MethodNotAllowedException $exception);
+
+    /**
+     * Taskied with handling a standard exception, expects a
+     * PSR-7 compatible middleware/callable to be returned
+     * or for the exception to simply be thrown.
+     *
+     * ```
+     * throw $exception;
+     * ```
+     * or
+     * ```
+     * return function ($request, $response) {
+     *     // ...
+     *     // it is recommended to return the response when decorating an exception
+     *     return $response;
+     * }
+     * ```
+     *
+     * @param \Exception $exception
+     *
+     * @return callable
+     */
+    public function getExceptionDecorator(Exception $exception);
 }

--- a/tests/Strategy/JsonStrategyTest.php
+++ b/tests/Strategy/JsonStrategyTest.php
@@ -53,6 +53,8 @@ class JsonStrategyTest extends \PHPUnit_Framework_TestCase
      */
     public function testStrategyBuildsJsonErrorResponseWhenNoResponseReturned()
     {
+        $this->setExpectedException('RuntimeException');
+
         $route    = $this->getMock('League\Route\Route');
         $callable = function (ServerRequestInterface $request, ResponseInterface $response, array $args = []) {};
 
@@ -66,59 +68,7 @@ class JsonStrategyTest extends \PHPUnit_Framework_TestCase
 
         $request  = $this->getMock('Psr\Http\Message\ServerRequestInterface');
         $response = $this->getMock('Psr\Http\Message\ResponseInterface');
-        $body     = $this->getMock('Psr\Http\Message\StreamInterface');
 
-        $body->expects($this->once())->method('write')->with($this->equalTo(json_encode([
-            'status_code'   => 500,
-            'reason_phrase' => 'Route callables must return an instance of (Psr\Http\Message\ResponseInterface)'
-        ], true)));
-
-        $response->expects($this->at(0))->method('getBody')->will($this->returnValue($body));
-        $response->expects($this->at(1))->method('withStatus')->with($this->equalTo(500))->will($this->returnSelf());
-        $response->expects($this->at(2))->method('withAddedHeader')->with($this->equalTo('content-type'), $this->equalTo('application/json'))->will($this->returnSelf());
-
-        $newResponse = $chain->execute($request, $response);
-
-        $this->assertSame($response, $newResponse);
-    }
-
-    /**
-     * Asserts that the strategy builds a json response for a controller that throws a http response.
-     *
-     * @return void
-     */
-    public function testStrategyBuildsJsonErrorResponseWhenControllerThrowsHttpException()
-    {
-        $route    = $this->getMock('League\Route\Route');
-        $callable = function (ServerRequestInterface $request, ResponseInterface $response, array $args = []) {
-            throw new BadRequestException;
-        };
-
-        $route->expects($this->once())->method('getCallable')->will($this->returnValue($callable));
-        $route->expects($this->once())->method('getMiddlewareStack')->will($this->returnValue([]));
-
-        $strategy = new JsonStrategy;
-        $chain    = $strategy->getExecutionChain($route, []);
-
-        $this->assertInstanceOf('League\Route\Middleware\ExecutionChain', $chain);
-
-        $request  = $this->getMock('Psr\Http\Message\ServerRequestInterface');
-        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
-        $body     = $this->getMock('Psr\Http\Message\StreamInterface');
-
-        $body->expects($this->once())->method('isWritable')->will($this->returnValue(true));
-        $body->expects($this->once())->method('write')->with($this->equalTo(json_encode([
-            'status_code'   => 400,
-            'reason_phrase' => 'Bad Request'
-        ], true)));
-
-        $response->expects($this->at(0))->method('withAddedHeader')->with($this->equalTo('content-type'), $this->equalTo('application/json'))->will($this->returnSelf());
-        $response->expects($this->at(1))->method('getBody')->will($this->returnValue($body));
-        $response->expects($this->at(2))->method('getBody')->will($this->returnValue($body));
-        $response->expects($this->at(3))->method('withStatus')->with($this->equalTo(400), $this->equalTo('Bad Request'))->will($this->returnSelf());
-
-        $newResponse = $chain->execute($request, $response);
-
-        $this->assertSame($response, $newResponse);
+        $chain->execute($request, $response);
     }
 }


### PR DESCRIPTION
This PR improves the way that exceptions are handled and possibly decorated, allowing the user to provide their own decorators as part of a custom strategy.