### PR TITLE
fix(dispatch): Fix re-prepRoutes while running in swoole

### DIFF
--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -147,9 +147,20 @@ class RouteCollection extends RouteCollector implements
             $this->setStrategy(new ApplicationStrategy);
         }
 
-        $this->prepRoutes($request);
+        if( !$this->isRoutesPrepared() )
+        {
+            $this->prepRoutes($request);
+        }
 
         return (new Dispatcher($this->getData()))->setStrategy($this->getStrategy());
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRoutesPrepared()
+    {
+        return !empty($this->dataGenerator->getData()[0]);
     }
 
     /**


### PR DESCRIPTION
In swoole, php is running as resident process, RouteCollection is kept in static Container, when
calling dispatch(),prepRoutes() is called , that causes BadRouteException