### PR TITLE
allow multiple dispatches.

### DIFF
--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -66,11 +66,6 @@ class RouteCollection extends RouteCollector implements
         '/{(.+?):uuid}/'          => '{$1:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}+}'
     ];
 
-    /*
-     * @var bool
-     */
-    protected $routesPrepared = false;
-
     /**
      * Constructor.
      *

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -60,6 +60,11 @@ class RouteCollection extends RouteCollector implements
         '/{(.+?):uuid}/'          => '{$1:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}+}'
     ];
 
+    /*
+     * @var bool
+     */
+    protected $routesPrepared = false;
+
     /**
      * Constructor.
      *
@@ -162,6 +167,9 @@ class RouteCollection extends RouteCollector implements
      */
     protected function prepRoutes(ServerRequestInterface $request)
     {
+        if ($this->routesPrepared) {
+            return;
+        }
         $this->buildNameIndex();
 
         $routes = array_merge(array_values($this->routes), array_values($this->namedRoutes));
@@ -189,6 +197,7 @@ class RouteCollection extends RouteCollector implements
                 [$route, 'getExecutionChain']
             );
         }
+        $this->routesPrepared = true;
     }
 
     /**

--- a/tests/DispatchIntegrationTest.php
+++ b/tests/DispatchIntegrationTest.php
@@ -266,4 +266,32 @@ class DispatchIntegrationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($response, $returnedResponse);
     }
+
+    /**
+     * Asserts that a route cannot be added after dispatcher has been built
+     * @return void
+     */
+    public function testThatRoutesCannotBeAddedAfterDispatch()
+    {
+        $collection = new RouteCollection;
+
+        $collection->map('GET', '/something', function (ServerRequestInterface $request, ResponseInterface $response) {
+            return $response;
+        });
+
+        $request  = $this->getMock('Psr\Http\Message\ServerRequestInterface');
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $uri      = $this->getMock('Psr\Http\Message\UriInterface');
+
+        $uri->expects($this->once())->method('getPath')->will($this->returnValue('/something'));
+
+        $request->method('getMethod')->will($this->returnValue('GET'));
+        $request->method('getUri')->will($this->returnValue($uri));
+
+        $collection->dispatch($request, $response);
+        $this->setExpectedException('Exception', 'Cannot add routes after dispatching a request');
+        $collection->map('GET', '/something-else', function (ServerRequestInterface $request, ResponseInterface $response) {
+            return $response;
+        });
+    }
 }

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -129,4 +129,19 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('League\Route\Dispatcher', $dispatcher);
     }
+
+    /**
+     * Asserts that collection can get dispatcher multiple times.
+     *
+     * @return void
+     */
+    public function testCollectionGetDispatcherMultipleTimes()
+    {
+        $collection = new RouteCollection;
+        $request    = $this->getMock('Psr\Http\Message\ServerRequestInterface');
+        $collection->map('get', '/something', function () {});
+
+        $collection->getDispatcher($request);
+        $collection->getDispatcher($request);
+    }
 }

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -115,11 +115,6 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = new RouteCollection;
         $request    = $this->getMock('Psr\Http\Message\ServerRequestInterface');
-        $uri        = $this->getMock('Psr\Http\Message\UriInterface');
-
-        $uri->expects($this->exactly(2))->method('getScheme')->will($this->returnValue('https'));
-        $uri->expects($this->exactly(2))->method('getHost')->will($this->returnValue('something.com'));
-        $request->expects($this->exactly(4))->method('getUri')->will($this->returnValue($uri));
 
         $collection->map('get', '/something', function () {})->setScheme('http');
         $collection->map('post', '/something', function () {})->setHost('example.com');
@@ -131,7 +126,8 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Asserts that collection can get dispatcher multiple times.
+     * Asserts that collection can get dispatcher multiple times, and that
+     * the same dispatcher instance is returned.
      *
      * @return void
      */
@@ -141,7 +137,9 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $request    = $this->getMock('Psr\Http\Message\ServerRequestInterface');
         $collection->map('get', '/something', function () {});
 
-        $collection->getDispatcher($request);
-        $collection->getDispatcher($request);
+        $this->assertSame(
+            $collection->getDispatcher($request),
+            $collection->getDispatcher($request)
+        );
     }
 }


### PR DESCRIPTION
Prepare routes once on first call to getDispatcher(), rather than once
per call. This allows daemonised/resident processes (eg swoole or reactphp)
to dispatch multiple requests.
Based on pull request #149 from jyj1993126.