### PR TITLE
Fix problem with multiline exception messages

### DIFF
--- a/src/Strategy/JsonStrategy.php
+++ b/src/Strategy/JsonStrategy.php
@@ -70,7 +70,7 @@ class JsonStrategy implements StrategyInterface
             ]));
 
             $response = $response->withAddedHeader('content-type', 'application/json');
-            return $response->withStatus(500, $exception->getMessage());
+            return $response->withStatus(500, strtok($exception->getMessage(), "\n"));
         };
     }
 }

--- a/tests/Strategy/JsonStrategyTest.php
+++ b/tests/Strategy/JsonStrategyTest.php
@@ -3,13 +3,9 @@
 namespace League\Route\Test\Strategy;
 
 use Exception;
-use League\Route\Http\Exception\BadRequestException;
-use League\Route\Middleware\ExecutionChain;
 use League\Route\Strategy\JsonStrategy;
-use League\Route\Test\Asset\Controller;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\StreamInterface;
 
 class JsonStrategyTest extends \PHPUnit_Framework_TestCase
 {
@@ -52,16 +48,16 @@ class JsonStrategyTest extends \PHPUnit_Framework_TestCase
         $strategy = new JsonStrategy;
         $callable = $strategy->getExceptionDecorator($exception);
 
-        $request = $this->prophesize(ServerRequestInterface::class);
+        $request = $this->prophesize('\Psr\Http\Message\ServerRequestInterface');
 
-        $stream = $this->prophesize(StreamInterface::class);
+        $stream = $this->prophesize('\Psr\Http\Message\StreamInterface');
         $stream->write(json_encode([
             'status_code'   => 500,
             'reason_phrase' => "some long message\nwith multiple\nlines",
         ]))
             ->shouldBeCalled();
 
-        $response = $this->prophesize(ResponseInterface::class);
+        $response = $this->prophesize('\Psr\Http\Message\ResponseInterface');
 
         $response->getBody()
             ->shouldBeCalled()

--- a/tests/Strategy/JsonStrategyTest.php
+++ b/tests/Strategy/JsonStrategyTest.php
@@ -2,11 +2,14 @@
 
 namespace League\Route\Test\Strategy;
 
+use Exception;
 use League\Route\Http\Exception\BadRequestException;
+use League\Route\Middleware\ExecutionChain;
 use League\Route\Strategy\JsonStrategy;
 use League\Route\Test\Asset\Controller;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 
 class JsonStrategyTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,5 +38,43 @@ class JsonStrategyTest extends \PHPUnit_Framework_TestCase
         };
 
         $callable($request, $response, $next);
+    }
+
+    /**
+     * Test exception decorator will only use the first message line for reason phrase.
+     *
+     * @return void
+     */
+    public function testExceptionDecoratorWillOnlyUseTheFirstMessageLineForReasonPhrase()
+    {
+        $exception = new Exception("some long message\nwith multiple\nlines");
+
+        $strategy = new JsonStrategy;
+        $callable = $strategy->getExceptionDecorator($exception);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+
+        $stream = $this->prophesize(StreamInterface::class);
+        $stream->write(json_encode([
+            'status_code'   => 500,
+            'reason_phrase' => "some long message\nwith multiple\nlines",
+        ]))
+            ->shouldBeCalled();
+
+        $response = $this->prophesize(ResponseInterface::class);
+
+        $response->getBody()
+            ->shouldBeCalled()
+            ->willReturn($stream->reveal());
+
+        $response->withAddedHeader('content-type', 'application/json')
+            ->shouldBeCalled()
+            ->willReturn($response->reveal());
+
+        $response->withStatus(500, 'some long message')
+            ->shouldBeCalled()
+            ->willReturn($response->reveal());
+
+        $callable($request->reveal(), $response->reveal());
     }
 }


### PR DESCRIPTION
Only use first line from exception message to build reason phrase.
Multi line message may occur in error as the header does not support new lines.