### PR TITLE
Don't override content-type if it's already set

### DIFF
--- a/src/Strategy/JsonStrategy.php
+++ b/src/Strategy/JsonStrategy.php
@@ -30,7 +30,11 @@ class JsonStrategy implements StrategyInterface
             $response = $return;
             $response = $next($request, $response);
 
-            return $response->withAddedHeader('content-type', 'application/json');
+            if (!$response->hasHeader('content-type'))
+            {
+                return $response->withHeader('content-type', 'application/json');
+            }
+            return $response;
         };
     }
 


### PR DESCRIPTION
JsonStrategy might return different `content-type` which we don't want to be overridden.

Also there can only be one `content-type` header so use `withHeader`

Otherwise currently using `withAddedHeader` we would add 2  'content-type' headers with undefined priority.

