### PR TITLE
Allow array or object responses when using the JsonStrategy

### DIFF
--- a/docs/4.x/strategies.md
+++ b/docs/4.x/strategies.md
@@ -106,7 +106,7 @@ The application strategy simply allows any exceptions to bubble out, you can cat
 
 ## JSON Strategy
 
-`League\Route\Strategy\JsonStrategy` aims to make building JSON APIs a little easier. It provides a PSR-7 `Psr\Http\Message\ServerRequestInterface` implementation and any route arguments to the controller as with the application strategy, the difference being that you can either build and return a response yourself or return an array and a JSON response will be built for you.
+`League\Route\Strategy\JsonStrategy` aims to make building JSON APIs a little easier. It provides a PSR-7 `Psr\Http\Message\ServerRequestInterface` implementation and any route arguments to the controller as with the application strategy, the difference being that you can either build and return a response yourself or return an array or object, and a JSON response will be built for you.
 
 To make use of the JSON strategy, you will need to provide it with a [PSR-17](https://www.php-fig.org/psr/psr-17/) response factory implementation. Some examples of HTTP Factory packages can be found [here](https://github.com/http-interop?utf8=%E2%9C%93&q=http-factory&type=&language=). We will use the `zend-diactoros` factory as an example.
 

--- a/src/Strategy/JsonStrategy.php
+++ b/src/Strategy/JsonStrategy.php
@@ -36,7 +36,7 @@ class JsonStrategy implements ContainerAwareInterface, StrategyInterface
     {
         $response = call_user_func_array($route->getCallable($this->getContainer()), [$request, $route->getVars()]);
 
-        if (is_array($response)) {
+        if ($this->isJsonEncodable($response)) {
             $body     = json_encode($response);
             $response = $this->responseFactory->createResponse();
             $response = $response->withStatus(200);
@@ -48,6 +48,21 @@ class JsonStrategy implements ContainerAwareInterface, StrategyInterface
         }
 
         return $response;
+    }
+
+    /**
+     * Check if the response can be converted to json
+     * Arrays can always be converted, objects can be converted if they're not a response already
+     *
+     * @param $response
+     *
+     * @return bool
+     */
+    private function isJsonEncodable($response):bool{
+        if (! (is_array($response) || is_object($response))){
+            return false;
+        }
+        return ! ($response instanceof ResponseInterface);
     }
 
     /**


### PR DESCRIPTION
A better version of #183 :
JsonStrategy will now convert both arrays and objects to json. If the object already implements ResponseInterface it won't be converted.