### PR TITLE
Improve documentation

### DIFF
--- a/docs/2.x/strategies.md
+++ b/docs/2.x/strategies.md
@@ -99,7 +99,7 @@ $route->get('/hello/{name1}/{name2}', function (ServerRequestInterface $request,
 });
 ~~~
 
-When the above controller is invoked, the strategy will reflect on it's parameters, attempt to resolve `ServerRequestInterface` from the container, and pass the dynamic parts of the route to the corresponding parameter names.
+When the above controller is invoked, the strategy will reflect on its parameters, attempt to resolve `ServerRequestInterface` from the container, and pass the dynamic parts of the route to the corresponding parameter names.
 
 ## JSON Strategy
 

--- a/docs/4.x/http.md
+++ b/docs/4.x/http.md
@@ -71,7 +71,7 @@ Route does not provide any functionality for dealing with globals such as `$_GET
 
 ## The Response
 
-Because Route is built around PSR-15, this means that middleware and controllers are handles in a [single pass](https://www.php-fig.org/psr/psr-15/meta/#52-single-pass-lambda) approach. What this means in practice is that all middleware is passed a request object but is expected to build and return it's own response or pass off to the next middleware in the stack for that to create one. Any controller that is dispatched via Route is wrapped in a middleware that adheres to this.
+Because Route is built around PSR-15, this means that middleware and controllers are handles in a [single pass](https://www.php-fig.org/psr/psr-15/meta/#52-single-pass-lambda) approach. What this means in practice is that all middleware is passed a request object but is expected to build and return its own response or pass off to the next middleware in the stack for that to create one. Any controller that is dispatched via Route is wrapped in a middleware that adheres to this.
 
 Onced wrapped, your controller ultimately becomes the last middleware in the stack (this does not mean that it has to be invoked last, see [middleware](/4.x/middleware) for more on this), it just means that it will only be concerned with creating and returning a response object.
 

--- a/docs/4.x/strategies.md
+++ b/docs/4.x/strategies.md
@@ -23,7 +23,7 @@ Strategies can be applied in three ways, each takes precedence over the previous
 
 ### Globally
 
-Will apply to all routes defined by the router unless the route or it's parent group has a different strategy applied.
+Will apply to all routes defined by the router unless the route or its parent group has a different strategy applied.
 
 ~~~php
 <?php declare(strict_types=1);
@@ -56,7 +56,7 @@ $router
 
 ### Per Route
 
-A strategy can be applied to any specific route, at top level or within a group, this will take precedence over any strategy applied to it's parent group or globally.
+A strategy can be applied to any specific route, at top level or within a group, this will take precedence over any strategy applied to its parent group or globally.
 
 ~~~php
 <?php declare(strict_types=1);

--- a/docs/4.x/strategies.md
+++ b/docs/4.x/strategies.md
@@ -72,7 +72,7 @@ $router
     ->group('/group', function ($router) {
         $router
             ->map('GET', '/acme/route', 'Acme\Controller::action')
-            ->setStrategy(new CustomStrategy) // will not ignore the strategy applied to the group
+            ->setStrategy(new CustomStrategy) // will ignore the strategy applied to the group
         ;
     })
     ->setStrategy(new ApplicationStrategy)

--- a/docs/unstable/http.md
+++ b/docs/unstable/http.md
@@ -71,7 +71,7 @@ Route does not provide any functionality for dealing with globals such as `$_GET
 
 ## The Response
 
-Because Route is built around PSR-15, this means that middleware and controllers are handles in a [single pass](https://www.php-fig.org/psr/psr-15/meta/#52-single-pass-lambda) approach. What this means in practice is that all middleware is passed a request object but is expected to build and return it's own response or pass off to the next middleware in the stack for that to create one. Any controller that is dispatched via Route is wrapped in a middleware that adheres to this.
+Because Route is built around PSR-15, this means that middleware and controllers are handles in a [single pass](https://www.php-fig.org/psr/psr-15/meta/#52-single-pass-lambda) approach. What this means in practice is that all middleware is passed a request object but is expected to build and return its own response or pass off to the next middleware in the stack for that to create one. Any controller that is dispatched via Route is wrapped in a middleware that adheres to this.
 
 Onced wrapped, your controller ultimately becomes the last middleware in the stack (this does not mean that it has to be invoked last, see [middleware](/unstable/middleware) for more on this), it just means that it will only be concerned with creating and returning a response object.
 

--- a/docs/unstable/strategies.md
+++ b/docs/unstable/strategies.md
@@ -23,7 +23,7 @@ Strategies can be applied in three ways, each takes precedence over the previous
 
 ### Globally
 
-Will apply to all routes defined by the router unless the route or it's parent group has a different strategy applied.
+Will apply to all routes defined by the router unless the route or its parent group has a different strategy applied.
 
 ~~~php
 <?php declare(strict_types=1);
@@ -56,7 +56,7 @@ $router
 
 ### Per Route
 
-A strategy can be applied to any specific route, at top level or within a group, this will take precedence over any strategy applied to it's parent group or globally.
+A strategy can be applied to any specific route, at top level or within a group, this will take precedence over any strategy applied to its parent group or globally.
 
 ~~~php
 <?php declare(strict_types=1);

--- a/docs/unstable/strategies.md
+++ b/docs/unstable/strategies.md
@@ -72,7 +72,7 @@ $router
     ->group('/group', function ($router) {
         $router
             ->map('GET', '/acme/route', 'Acme\Controller::action')
-            ->setStrategy(new CustomStrategy) // will not ignore the strategy applied to the group
+            ->setStrategy(new CustomStrategy) // will ignore the strategy applied to the group
         ;
     })
     ->setStrategy(new ApplicationStrategy)


### PR DESCRIPTION
This PR contains two documentation improvements:
- Some instances of "its" being misspelled as "it's" were corrected. I hope this isn't too pedantic, but I noticed it while reading, so I thought I'd go ahead and fix it.
- An extra word was removed from a code comment in the strategies documentation. I was confused by the comment, because it seemed to contradict the paragraph right above it. I'm pretty sure an extra "not" sneaked in by accident, so I removed it.