### PR TITLE
Fix route-specific strategies

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -70,7 +70,7 @@ class Dispatcher extends GroupCountBasedDispatcher implements
      */
     protected function setFoundMiddleware(Route $route) : void
     {
-        if (! is_null($route->getStrategy())) {
+        if (is_null($route->getStrategy())) {
             $route->setStrategy($this->getStrategy());
         }
 


### PR DESCRIPTION
This commit fixes issue #190, where setting a strategy on a route had no effect.

I'm not that excited about the tests, since they're long and the assertions are hidden in the mock expectations. However, they will fail if there's a regression and I couldn't figure out a better way to test for the bug. Suggestions for improvement would be most welcome.