### PR TITLE
Fix Broken Installation Link

### DIFF
--- a/docs/4.x/usage.md
+++ b/docs/4.x/usage.md
@@ -10,7 +10,7 @@ sections:
 
 It is very easy to get up and running with Route.
 
-Firstly you need to look at our [installation guide](/4.x/installation).
+Firstly you need to look at our [installation guide](/4.x/#installation).
 
 ~~~
 composer require league/route


### PR DESCRIPTION
The link currently causes a 404, from looking at the Installation Guide on the actual docs, this should fix it.