### PR TITLE
Repair broken links in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,12 @@ build
 composer.lock
 vendor
 .sass-cache
+
+### Jekyll ###
+docs/_site/
+docs/.sass-cache/
+docs/.jekyll-cache/
+docs/.jekyll-metadata
+
+### PhpStorm ###
+.idea/

--- a/docs/2.x/concepts.md
+++ b/docs/2.x/concepts.md
@@ -103,7 +103,7 @@ $route->map('GET', '/acme/route', 'AcmeController::method')->setHost('example.co
 $route->map('GET', '/acme/route', 'AcmeController::method')->setScheme('https')->setHost('example.com');
 ~~~
 
-Conditions can also be applied across [route groups](/route-groups/).
+Conditions can also be applied across [route groups](#route-groups).
 
 ## Route Groups
 
@@ -129,7 +129,7 @@ GET /admin/acme/route2
 GET /admin/acme/route3
 ~~~
 
-Route [conditions](/route-conditions/) can be applied to a group and will be matched across all routes contained in that group, specific routes within the group can override this functionality as displayed below.
+Route [conditions](#route-conditions) can be applied to a group and will be matched across all routes contained in that group, specific routes within the group can override this functionality as displayed below.
 
 ~~~php
 <?php

--- a/docs/2.x/concepts.md
+++ b/docs/2.x/concepts.md
@@ -10,7 +10,7 @@ sections:
 ---
 ## Wildcard Routes
 
-Wilcard routes allow a route to respond to dynamic parts of a URI. If a route has dynamic parts, they will be passed in to the controller as an associative array of arguments.
+Wildcard routes allow a route to respond to dynamic parts of a URI. If a route has dynamic parts, they will be passed in to the controller as an associative array of arguments.
 
 ~~~php
 <?php

--- a/docs/2.x/index.md
+++ b/docs/2.x/index.md
@@ -9,7 +9,7 @@ sections:
 ---
 [![Author](http://img.shields.io/badge/author-@philipobenito-blue.svg?style=flat-square)](https://twitter.com/philipobenito)
 [![Latest Version](https://img.shields.io/github/release/thephpleague/route.svg?style=flat-square)](https://github.com/thephpleague/route/releases)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](https://github.com/thephpleague/route/blob/master/LICENSE.md)
 [![Build Status](https://img.shields.io/travis/thephpleague/route/master.svg?style=flat-square)](https://travis-ci.org/thephpleague/route)
 [![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/thephpleague/route.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/route/code-structure)
 [![Quality Score](https://img.shields.io/scrutinizer/g/thephpleague/route.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/route)

--- a/docs/3.x/concepts.md
+++ b/docs/3.x/concepts.md
@@ -11,7 +11,7 @@ sections:
 ---
 ## Wildcard Routes
 
-Wilcard routes allow a route to respond to dynamic parts of a URI. If a route has dynamic parts, they will be passed in to the controller as an associative array of arguments.
+Wildcard routes allow a route to respond to dynamic parts of a URI. If a route has dynamic parts, they will be passed in to the controller as an associative array of arguments.
 
 ~~~php
 <?php

--- a/docs/3.x/concepts.md
+++ b/docs/3.x/concepts.md
@@ -112,7 +112,7 @@ $route->map('GET', '/acme/route', 'AcmeController::method')->setHost('example.co
 $route->map('GET', '/acme/route', 'AcmeController::method')->setScheme('https')->setHost('example.com');
 ~~~
 
-Conditions can also be applied across [route groups](/route-groups/).
+Conditions can also be applied across [route groups](#route-groups).
 
 ## Route Groups
 
@@ -138,7 +138,7 @@ GET /admin/acme/route2
 GET /admin/acme/route3
 ~~~
 
-Route [conditions](/route-conditions/) can be applied to a group and will be matched across all routes contained in that group, specific routes within the group can override this functionality as displayed below.
+Route [conditions](#route-conditions) can be applied to a group and will be matched across all routes contained in that group, specific routes within the group can override this functionality as displayed below.
 
 ~~~php
 <?php

--- a/docs/3.x/index.md
+++ b/docs/3.x/index.md
@@ -9,7 +9,7 @@ sections:
 ---
 [![Author](http://img.shields.io/badge/author-@philipobenito-blue.svg?style=flat-square)](https://twitter.com/philipobenito)
 [![Latest Version](https://img.shields.io/github/release/thephpleague/route.svg?style=flat-square)](https://github.com/thephpleague/route/releases)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](https://github.com/thephpleague/route/blob/master/LICENSE.md)
 [![Build Status](https://img.shields.io/travis/thephpleague/route/master.svg?style=flat-square)](https://travis-ci.org/thephpleague/route)
 [![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/thephpleague/route.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/route/code-structure)
 [![Quality Score](https://img.shields.io/scrutinizer/g/thephpleague/route.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/route)

--- a/docs/3.x/strategies.md
+++ b/docs/3.x/strategies.md
@@ -95,7 +95,7 @@ Whilst these are primitive and naive examples, it is good design to handle your 
 
 ### Exception Decorators
 
-The `ApplicationStrategy` simply allows any exceptions to bubble out, you can catch them in your bootstrap process or you have the option to extend this strategy and overload the exception decorator methods. See [Custom Strategies](/3.x/custom-strategies).
+The `ApplicationStrategy` simply allows any exceptions to bubble out, you can catch them in your bootstrap process or you have the option to extend this strategy and overload the exception decorator methods. See [Custom Strategies](#custom-strategies).
 
 ## Json Strategy
 

--- a/docs/3.x/usage.md
+++ b/docs/3.x/usage.md
@@ -2,21 +2,36 @@
 layout: post
 title: Usage
 sections:
+    Introduction: introduction
     Hello World: hello-world
 ---
-## Hello World
 
-It is very easy to get up and running with Route. This guide will help you create a simple "Hello, World!" application.
+## Installation
 
-Firstly you need to look at our [installation guide](/installation). You will also need to install an implementation of PSR-7.
+It is very easy to get up and running with Route. You can use [Composer][composer]
+to install and manage your installation of Route. You'll [need to install][dependencies] 
+both the Route project and an implementation of the [PSR-7 message interface][psr7]. 
 
+First, install the Route project itself:
 ~~~
 composer require league/route
 ~~~
 
+Next, install an implementation of PSR-7. We recommend the [Zend Diactoros project][diactoros].
+
 ~~~
 composer require zendframework/zend-diactoros
 ~~~
+
+Optionally, you could also install a PSR-11 dependency injection container, see [Dependency Injection](/4.x/dependency-injection) for more information.
+
+~~~
+composer require league/container
+~~~
+
+## Hello World
+
+Now that we have all the packages we need, we can a simple Hello, World! application in one file.
 
 ~~~php
 <?php
@@ -47,3 +62,8 @@ $response = $route->dispatch($container->get('request'), $container->get('respon
 
 $container->get('emitter')->emit($response);
 ~~~
+
+[composer]: https://getcomposer.org/
+[dependencies]: https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies
+[psr7]: https://www.php-fig.org/psr/psr-7/
+[diactoros]:https://github.com/zendframework/zend-diactoros/

--- a/docs/4.x/controllers.md
+++ b/docs/4.x/controllers.md
@@ -93,7 +93,7 @@ $router = new League\Route\Router;
 $router->map('GET', '/', 'Acme\SomeController::someMethod');
 ~~~
 
-### Lazy Loaded Class Implenting `__invoke` (Proxy)
+### Lazy Loaded Class Implementing `__invoke` (Proxy)
 
 You can define the name of a class that implements the magic `__invoke` method and the object will not be instantiated until it is dispatched.
 

--- a/docs/4.x/dependency-injection.md
+++ b/docs/4.x/dependency-injection.md
@@ -12,7 +12,7 @@ Route has the ability to use a [PSR-11](https://www.php-fig.org/psr/psr-11/) dep
 
 ## Recommended Reading
 
-It is recommended that if you have limited or no knowledge of dependency injection you should read about the concepts before you attempt to implement it. A good place to get started is with the [Dependency Injection chapter](https://www.phptherightway.com/#dependency_injection) pf PHP The Right Way.
+It is recommended that if you have limited or no knowledge of dependency injection you should read about the concepts before you attempt to implement it. A good place to get started is with the [Dependency Injection chapter](https://www.phptherightway.com/#dependency_injection) of PHP The Right Way.
 
 ## Using a Container
 

--- a/docs/4.x/http.md
+++ b/docs/4.x/http.md
@@ -73,7 +73,7 @@ Route does not provide any functionality for dealing with globals such as `$_GET
 
 Because Route is built around PSR-15, this means that middleware and controllers are handles in a [single pass](https://www.php-fig.org/psr/psr-15/meta/#52-single-pass-lambda) approach. What this means in practice is that all middleware is passed a request object but is expected to build and return its own response or pass off to the next middleware in the stack for that to create one. Any controller that is dispatched via Route is wrapped in a middleware that adheres to this.
 
-Onced wrapped, your controller ultimately becomes the last middleware in the stack (this does not mean that it has to be invoked last, see [middleware](/4.x/middleware) for more on this), it just means that it will only be concerned with creating and returning a response object.
+Once wrapped, your controller ultimately becomes the last middleware in the stack (this does not mean that it has to be invoked last, see [middleware](/4.x/middleware) for more on this), it just means that it will only be concerned with creating and returning a response object.
 
 An example of a controller building a response might look like this.
 
@@ -91,4 +91,4 @@ function controller(ServerRequestInterface $request) : ResponseInterface {
 }
 ~~~
 
-Route does not provide any functionality for creating or interacting with a response object. Please refer to the docuementation of whatever [PSR-7](https://www.php-fig.org/psr/psr-7/) implementation you have chosen to use for more information.
+Route does not provide any functionality for creating or interacting with a response object. For more information, please refer to the documentation of the [PSR-7](https://www.php-fig.org/psr/psr-7/) implementation that you have chosen to use

--- a/docs/4.x/index.md
+++ b/docs/4.x/index.md
@@ -18,7 +18,7 @@ sections:
 
 ## What is Route?
 
-Route is a fast PSR-7 routing/dispatcher package including PSR-15 middleware implementation that enabables you to build well designed performant web apps.
+Route is a fast PSR-7 routing/dispatcher package including PSR-15 middleware implementation that enables you to build well designed performant web apps.
 
 At its core is Nikita Popov's [FastRoute](https://github.com/nikic/FastRoute) package allowing this package to concentrate on the dispatch of your controllers.
 

--- a/docs/4.x/index.md
+++ b/docs/4.x/index.md
@@ -10,7 +10,7 @@ sections:
 ---
 [![Author](http://img.shields.io/badge/author-@philipobenito-blue.svg?style=flat-square)](https://twitter.com/philipobenito)
 [![Latest Version](https://img.shields.io/github/release/thephpleague/route.svg?style=flat-square)](https://github.com/thephpleague/route/releases)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](https://github.com/thephpleague/route/blob/master/LICENSE.md)
 [![Build Status](https://img.shields.io/travis/thephpleague/route/master.svg?style=flat-square)](https://travis-ci.org/thephpleague/route)
 [![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/thephpleague/route.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/route/code-structure)
 [![Quality Score](https://img.shields.io/scrutinizer/g/thephpleague/route.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/route)
@@ -26,7 +26,7 @@ At its core is Nikita Popov's [FastRoute](https://github.com/nikic/FastRoute) pa
 
 ## What isn't Route?
 
-Route is not a framework, it will not allow you to build an application out of the box. See [getting-started](/4.x/getting-started) for more information.
+Route is not a framework, it will not allow you to build an application out of the box.
 
 ## Goals
 

--- a/docs/4.x/middleware.md
+++ b/docs/4.x/middleware.md
@@ -16,7 +16,7 @@ sections:
 > A middleware component MAY create and return a response without delegating to
 > a request handler, if sufficient conditions are met.
 
-Route is a [PSR-15](https://www.php-fig.org/psr/psr-15/) server request handler, and as such can handle the invokation of a stack of middlewares.
+Route is a [PSR-15](https://www.php-fig.org/psr/psr-15/) server request handler, and as such can handle the invocation of a stack of middlewares.
 
 ## Example Middleware
 
@@ -108,7 +108,7 @@ $router
 
 Middleware is invoked in a specific order but depending on the logic contained in a middleware, you can control whether your code is run before or after your controller is invoked.
 
-The invokation order is as follows:
+The invocation order is as follows:
 
 1. Exception handler defined by the active strategy. This middleware should wrap the rest of the application and catch any exceptions to be gracefully handled.
 2. Middleware added to the router.

--- a/docs/4.x/routes.md
+++ b/docs/4.x/routes.md
@@ -140,7 +140,7 @@ GET http://example.com/admin/acme/route3
 
 ## Wildcard Routes
 
-Wilcard routes allow a route to respond to dynamic segments of a URI. If a route has dynamic URI segments, they will be passed in to the controller as an associative array of arguments.
+Wildcard routes allow a route to respond to dynamic segments of a URI. If a route has dynamic URI segments, they will be passed in to the controller as an associative array of arguments.
 
 ~~~php
 <?php declare(strict_types=1);

--- a/docs/4.x/usage.md
+++ b/docs/4.x/usage.md
@@ -10,7 +10,7 @@ sections:
 
 It is very easy to get up and running with Route. You can use [Composer][composer]
 to install and manage your installation of Route. You'll [need to install][dependencies] 
-both the Route package and an implementation of the [PSR-7 message interface][psr7]. 
+both the Route project and an implementation of the [PSR-7 message interface][psr7]. 
 
 First, install the Route project itself:
 ~~~

--- a/docs/4.x/usage.md
+++ b/docs/4.x/usage.md
@@ -8,15 +8,16 @@ sections:
 ---
 ## Introduction
 
-It is very easy to get up and running with Route.
+It is very easy to get up and running with Route. You can use [Composer][composer]
+to install and manage your installation of Route. You'll [need to install][dependencies] 
+both the Route package and an implementation of the [PSR-7 message interface][psr7]. 
 
-Firstly you need to look at our [installation guide](/4.x/installation).
-
+First, install the Route project itself:
 ~~~
 composer require league/route
 ~~~
 
-You will also need to install an implementation of PSR-7.
+Next, install an implementation of PSR-7. We recommend the [Zend Diactoros project][diactoros].
 
 ~~~
 composer require zendframework/zend-diactoros
@@ -108,3 +109,8 @@ The code above will build turn your returned array in to a JSON response.
     "version": 1
 }
 ~~~
+
+[composer]: https://getcomposer.org/
+[dependencies]: https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies
+[psr7]: https://www.php-fig.org/psr/psr-7/
+[diactoros]:https://github.com/zendframework/zend-diactoros/

--- a/docs/_data/releases.yml
+++ b/docs/_data/releases.yml
@@ -9,7 +9,6 @@
   menu:
     Getting Started: '/unstable/'
     Basic Usage: '/unstable/usage/'
-    Concepts: '/unstable/concepts/'
     Strategies: '/unstable/strategies/'
 -
   default: true

--- a/docs/unstable/controllers.md
+++ b/docs/unstable/controllers.md
@@ -93,7 +93,7 @@ $router = new League\Route\Router;
 $router->map('GET', '/', 'Acme\SomeController::someMethod');
 ~~~
 
-### Lazy Loaded Class Implenting `__invoke` (Proxy)
+### Lazy Loaded Class Implementing `__invoke` (Proxy)
 
 You can define the name of a class that implements the magic `__invoke` method and the object will not be instantiated until it is dispatched.
 

--- a/docs/unstable/http.md
+++ b/docs/unstable/http.md
@@ -73,7 +73,7 @@ Route does not provide any functionality for dealing with globals such as `$_GET
 
 Because Route is built around PSR-15, this means that middleware and controllers are handles in a [single pass](https://www.php-fig.org/psr/psr-15/meta/#52-single-pass-lambda) approach. What this means in practice is that all middleware is passed a request object but is expected to build and return its own response or pass off to the next middleware in the stack for that to create one. Any controller that is dispatched via Route is wrapped in a middleware that adheres to this.
 
-Onced wrapped, your controller ultimately becomes the last middleware in the stack (this does not mean that it has to be invoked last, see [middleware](/unstable/middleware) for more on this), it just means that it will only be concerned with creating and returning a response object.
+Once wrapped, your controller ultimately becomes the last middleware in the stack (this does not mean that it has to be invoked last, see [middleware](/unstable/middleware) for more on this), it just means that it will only be concerned with creating and returning a response object.
 
 An example of a controller building a response might look like this.
 
@@ -91,4 +91,4 @@ function controller(ServerRequestInterface $request) : ResponseInterface {
 }
 ~~~
 
-Route does not provide any functionality for creating or interacting with a response object. Please refer to the docuementation of whatever [PSR-7](https://www.php-fig.org/psr/psr-7/) implementation you have chosen to use for more information.
+Route does not provide any functionality for creating or interacting with a response object. For more information, please refer to the documentation of the [PSR-7](https://www.php-fig.org/psr/psr-7/) implementation that you have chosen to use.

--- a/docs/unstable/index.md
+++ b/docs/unstable/index.md
@@ -10,7 +10,7 @@ sections:
 ---
 [![Author](http://img.shields.io/badge/author-@philipobenito-blue.svg?style=flat-square)](https://twitter.com/philipobenito)
 [![Latest Version](https://img.shields.io/github/release/thephpleague/route.svg?style=flat-square)](https://github.com/thephpleague/route/releases)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](https://github.com/thephpleague/route/blob/master/LICENSE.md)
 [![Build Status](https://img.shields.io/travis/thephpleague/route/master.svg?style=flat-square)](https://travis-ci.org/thephpleague/route)
 [![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/thephpleague/route.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/route/code-structure)
 [![Quality Score](https://img.shields.io/scrutinizer/g/thephpleague/route.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/route)
@@ -18,7 +18,7 @@ sections:
 
 ## What is Route?
 
-Route is a fast PSR-7 routing/dispatcher package including PSR-15 middleware implementation that enabables you to build well designed performant web apps.
+Route is a fast PSR-7 routing/dispatcher package including PSR-15 middleware implementation that enables you to build well designed performant web apps.
 
 At its core is Nikita Popov's [FastRoute](https://github.com/nikic/FastRoute) package allowing this package to concentrate on the dispatch of your controllers.
 
@@ -26,7 +26,7 @@ At its core is Nikita Popov's [FastRoute](https://github.com/nikic/FastRoute) pa
 
 ## What isn't Route?
 
-Route is not a framework, it will not allow you to build an application out of the box. See [getting-started](/unstable/getting-started) for more information.
+Route is not a framework, it will not allow you to build an application out of the box. See our [usage documentation](/unstable/usage) for more information.
 
 ## Goals
 

--- a/docs/unstable/middleware.md
+++ b/docs/unstable/middleware.md
@@ -16,7 +16,7 @@ sections:
 > A middleware component MAY create and return a response without delegating to
 > a request handler, if sufficient conditions are met.
 
-Route is a [PSR-15](https://www.php-fig.org/psr/psr-15/) server request handler, and as such can handle the invokation of a stack of middlewares.
+Route is a [PSR-15](https://www.php-fig.org/psr/psr-15/) server request handler, and as such can handle the invocation of a stack of middlewares.
 
 ## Example Middleware
 
@@ -108,7 +108,7 @@ $router
 
 Middleware is invoked in a specific order but depending on the logic contained in a middleware, you can control whether your code is run before or after your controller is invoked.
 
-The invokation order is as follows:
+The invocation order is as follows:
 
 1. Exception handler defined by the active strategy. This middleware should wrap the rest of the application and catch any exceptions to be gracefully handled.
 2. Middleware added to the router.

--- a/docs/unstable/routes.md
+++ b/docs/unstable/routes.md
@@ -140,7 +140,7 @@ GET http://example.com/admin/acme/route3
 
 ## Wildcard Routes
 
-Wilcard routes allow a route to respond to dynamic segments of a URI. If a route has dynamic URI segments, they will be passed in to the controller as an associative array of arguments.
+Wildcard routes allow a route to respond to dynamic segments of a URI. If a route has dynamic URI segments, they will be passed in to the controller as an associative array of arguments.
 
 ~~~php
 <?php declare(strict_types=1);

--- a/docs/unstable/strategies.md
+++ b/docs/unstable/strategies.md
@@ -102,7 +102,7 @@ function controller(ServerRequestInterface $request, array $args) : ResponseInte
 
 ### Exception Decorators
 
-The applkication strategy simply allows any exceptions to bubble out, you can catch them in your bootstrap process or you have the option to extend this strategy and overload the exception decorator methods. See [Custom Strategies](#custom-strategies).
+The [application strategy](https://github.com/thephpleague/route/blob/master/src/Strategy/ApplicationStrategy.php) simply allows any exceptions to bubble out, you can catch them in your bootstrap process or you have the option to extend this strategy and overload the exception decorator methods. See [Custom Strategies](#custom-strategies).
 
 ## JSON Strategy
 

--- a/docs/unstable/usage.md
+++ b/docs/unstable/usage.md
@@ -23,7 +23,7 @@ Next, install an implementation of PSR-7. We recommend the [Zend Diactoros proje
 composer require zendframework/zend-diactoros
 ~~~
 
-Optionally, you could also install a PSR-11 dependency injection container, see [Dependency Injection](/4.x/dependency-injection) for more information.
+Optionally, you could also install a PSR-11 dependency injection container, see [Dependency Injection](/unstable/dependency-injection) for more information.
 
 ~~~
 composer require league/container

--- a/docs/unstable/usage.md
+++ b/docs/unstable/usage.md
@@ -8,21 +8,22 @@ sections:
 ---
 ## Introduction
 
-It is very easy to get up and running with Route.
+It is very easy to get up and running with Route. You can use [Composer][composer]
+to install and manage your installation of Route. You'll [need to install][dependencies] 
+both the Route project and an implementation of the [PSR-7 message interface][psr7]. 
 
-Firstly you need to look at our [installation guide](/unstable/installation).
-
+First, install the Route project itself:
 ~~~
 composer require league/route
 ~~~
 
-You will also need to install an implementation of PSR-7.
+Next, install an implementation of PSR-7. We recommend the [Zend Diactoros project][diactoros].
 
 ~~~
 composer require zendframework/zend-diactoros
 ~~~
 
-Optionally, you could also install a PSR-11 dependency injection container, see [Dependency Injection](/unstable/dependency-injection) for more information.
+Optionally, you could also install a PSR-11 dependency injection container, see [Dependency Injection](/4.x/dependency-injection) for more information.
 
 ~~~
 composer require league/container
@@ -104,3 +105,8 @@ The code above will build turn your returned array in to a JSON response.
     "version": 1
 }
 ~~~
+
+[composer]: https://getcomposer.org/
+[dependencies]: https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies
+[psr7]: https://www.php-fig.org/psr/psr-7/
+[diactoros]:https://github.com/zendframework/zend-diactoros/


### PR DESCRIPTION
## Problem
The Route documentation has some broken links and minor spelling errors. 

## Background
While using the Route project, I noticed a few broken links in the 3.x documentation. I then did a little clicking around and saw a few other broken links. I based this PR on the results from two tools:

* [Broken Link Checker](https://davidwalsh.name/broken-link-checker) run on a local `jekyll serve` with `blc http://127.0.0.1:4000 -ro`
* [Markdown Spellcheck](https://www.npmjs.com/package/markdown-spellcheck) run as `mdspell -n -r  "**/*.md"`

## Solution
Quite a few of the broken links were links to separate files when they should have been links to page sections. 

1. Update the `.gitignore` with rules for the generated Jekyll `_site` when running locally.
1. Update the `.gitignore` with rules for PHPStorm.
1. Fix links in 2.x, 3.x, 4.x, and unstable documenation directories and confirm with the `blc` tool.
1. Remove the link in `docs/_data/releases.yml` that was to a missing page.
1. Update spelling errors reported by `mdspell`.
1. Minor changes to the getting started pages 

## Review Notes
There are no changes to the Route source. This is a documenation only