### PR TITLE
Documentation clean up and minor optimizations

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,9 +1,11 @@
 <?xml version="1.0"?>
 <ruleset name="PSR2-PHP7">
     <description>PSR2 ruleset ignoring only grouped use statements.</description>
-     <rule ref="PSR2">
-         <exclude name="PSR2.Namespaces.UseDeclaration"/>
-     </rule>
+    <rule ref="PSR2">
+        <exclude name="PSR2.Namespaces.UseDeclaration"/>
+    </rule>
+    <file>src/</file>
+    <file>tests/</file>
     <exclude-pattern>*/vendor/*</exclude-pattern>
     <exclude-pattern>*.js</exclude-pattern>
     <exclude-pattern>*.css</exclude-pattern>

--- a/src/ContainerAwareInterface.php
+++ b/src/ContainerAwareInterface.php
@@ -7,18 +7,18 @@ use Psr\Container\ContainerInterface;
 interface ContainerAwareInterface
 {
     /**
-     * Get container.
+     * Get the current container
      *
-     * @return \Psr\Container\ContainerInterface
+     * @return \Psr\Container\ContainerInterface|null
      */
     public function getContainer() : ?ContainerInterface;
 
     /**
-     * Set container.
+     * Set the container implementation
      *
      * @param \Psr\Container\ContainerInterface $container
      *
-     * @return \League\Route\ContainerAwareInterface
+     * @return static
      */
     public function setContainer(ContainerInterface $container) : ContainerAwareInterface;
 }

--- a/src/ContainerAwareTrait.php
+++ b/src/ContainerAwareTrait.php
@@ -7,14 +7,12 @@ use Psr\Container\ContainerInterface;
 trait ContainerAwareTrait
 {
     /**
-     * @var \Psr\Container\ContainerInterface
+     * @var \Psr\Container\ContainerInterface|null
      */
     protected $container;
 
     /**
-     * Get container.
-     *
-     * @return \Psr\Container\ContainerInterface
+     * {@inheritdoc}
      */
     public function getContainer() : ?ContainerInterface
     {
@@ -22,11 +20,7 @@ trait ContainerAwareTrait
     }
 
     /**
-     * Set container.
-     *
-     * @param \Psr\Container\ContainerInterface $container
-     *
-     * @return \League\Route\ContainerAwareInterface
+     * {@inheritdoc}
      */
     public function setContainer(ContainerInterface $container) : ContainerAwareInterface
     {

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -20,7 +20,7 @@ class Dispatcher extends GroupCountBasedDispatcher implements
     use StrategyAwareTrait;
 
     /**
-     * Dispatch the current route.
+     * Dispatch the current route
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request
      *
@@ -62,7 +62,7 @@ class Dispatcher extends GroupCountBasedDispatcher implements
     }
 
     /**
-     * Handle dispatching of a found route.
+     * Set up middleware for a found route
      *
      * @param \League\Route\Route $route
      *
@@ -89,7 +89,7 @@ class Dispatcher extends GroupCountBasedDispatcher implements
     }
 
     /**
-     * Handle a not found route.
+     * Set up middleware for a not found route
      *
      * @return void
      */
@@ -100,7 +100,7 @@ class Dispatcher extends GroupCountBasedDispatcher implements
     }
 
     /**
-     * Handles a not allowed route.
+     * Set up middleware for a not allowed route
      *
      * @param array $allowed
      *

--- a/src/Middleware/MiddlewareAwareInterface.php
+++ b/src/Middleware/MiddlewareAwareInterface.php
@@ -7,36 +7,36 @@ use Psr\Http\Server\MiddlewareInterface;
 interface MiddlewareAwareInterface
 {
     /**
-     * Add a middleware to the stack.
+     * Add a middleware to the stack
      *
      * @param \Psr\Http\Server\MiddlewareInterface $middleware
      *
-     * @return self
+     * @return static
      */
     public function middleware(MiddlewareInterface $middleware) : MiddlewareAwareInterface;
 
     /**
-     * Add a middleware to the stack.
+     * Add multiple middleware to the stack
      *
      * @param \Psr\Http\Server\MiddlewareInterface[] $middlewares
      *
-     * @return self
+     * @return static
      */
     public function middlewares(array $middlewares) : MiddlewareAwareInterface;
 
     /**
-     * Add a middleware to the stack.
+     * Prepend a middleware to the stack
      *
      * @param \Psr\Http\Server\MiddlewareInterface $middleware
      *
-     * @return self
+     * @return static
      */
     public function prependMiddleware(MiddlewareInterface $middleware) : MiddlewareAwareInterface;
 
     /**
-     * Shift middleware from beginning of stack.
+     * Shift a middleware from beginning of stack
      *
-     * @return \Psr\Http\Server\MiddlewareInterface
+     * @return \Psr\Http\Server\MiddlewareInterface|null
      */
     public function shiftMiddleware() : MiddlewareInterface;
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -62,11 +62,11 @@ class Route implements
     }
 
     /**
-     * Get the callable.
+     * Get the controller callable
      *
-     * @param \Psr\Container\ContainerInterface $container
+     * @param \Psr\Container\ContainerInterface|null $container
      *
-     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      *
      * @return callable
      */
@@ -106,7 +106,7 @@ class Route implements
     }
 
     /**
-     * Return vars to be passed to route callable.
+     * Return variables to be passed to route callable
      *
      * @return array
      */
@@ -116,7 +116,7 @@ class Route implements
     }
 
     /**
-     * Set vars to be passed to route callable.
+     * Set variables to be passed to route callable
      *
      * @param array $vars
      *
@@ -130,7 +130,7 @@ class Route implements
     }
 
     /**
-     * Get the parent group.
+     * Get the parent group
      *
      * @return \League\Route\RouteGroup
      */
@@ -140,7 +140,7 @@ class Route implements
     }
 
     /**
-     * Set the parent group.
+     * Set the parent group
      *
      * @param \League\Route\RouteGroup $group
      *
@@ -154,7 +154,7 @@ class Route implements
     }
 
     /**
-     * Get the path.
+     * Get the path
      *
      * @return string
      */
@@ -164,7 +164,7 @@ class Route implements
     }
 
     /**
-     * Get the methods.
+     * Get the HTTP method
      *
      * @return string
      */

--- a/src/Route.php
+++ b/src/Route.php
@@ -83,19 +83,11 @@ class Route implements
         }
 
         if (is_array($callable) && isset($callable[0]) && is_string($callable[0])) {
-            $class = (! is_null($container) && $container->has($callable[0]))
-                ? $container->get($callable[0])
-                : new $callable[0]
-            ;
-
-            $callable = [$class, $callable[1]];
+            $callable = [$this->resolveClass($container, $callable[0]), $callable[1]];
         }
 
         if (is_string($callable) && method_exists($callable, '__invoke')) {
-            $callable = (! is_null($container) && $container->has($callable))
-                ? $container->get($callable)
-                : new $callable
-            ;
+            $callable = $this->resolveClass($container, $callable);
         }
 
         if (! is_callable($callable)) {
@@ -103,6 +95,23 @@ class Route implements
         }
 
         return $callable;
+    }
+
+    /**
+     * Get an object instance from a class name
+     *
+     * @param \Psr\Container\ContainerInterface|null $container
+     * @param string $class
+     *
+     * @return object
+     */
+    protected function resolveClass(?ContainerInterface $container = null, string $class)
+    {
+        if ($container instanceof ContainerInterface && $container->has($class)) {
+            return $container->get($class);
+        }
+
+        return new $class();
     }
 
     /**

--- a/src/RouteCollectionInterface.php
+++ b/src/RouteCollectionInterface.php
@@ -5,7 +5,7 @@ namespace League\Route;
 interface RouteCollectionInterface
 {
     /**
-     * Add a route to the map.
+     * Add a route to the map
      *
      * @param string          $method
      * @param string          $path
@@ -16,7 +16,7 @@ interface RouteCollectionInterface
     public function map(string $method, string $path, $handler) : Route;
 
     /**
-     * Add a route that responds to GET HTTP method.
+     * Add a route that responds to GET HTTP method
      *
      * @param string          $path
      * @param callable|string $handler
@@ -26,7 +26,7 @@ interface RouteCollectionInterface
     public function get($path, $handler);
 
     /**
-     * Add a route that responds to POST HTTP method.
+     * Add a route that responds to POST HTTP method
      *
      * @param string          $path
      * @param callable|string $handler
@@ -36,7 +36,7 @@ interface RouteCollectionInterface
     public function post($path, $handler);
 
     /**
-     * Add a route that responds to PUT HTTP method.
+     * Add a route that responds to PUT HTTP method
      *
      * @param string          $path
      * @param callable|string $handler
@@ -46,7 +46,7 @@ interface RouteCollectionInterface
     public function put($path, $handler);
 
     /**
-     * Add a route that responds to PATCH HTTP method.
+     * Add a route that responds to PATCH HTTP method
      *
      * @param string          $path
      * @param callable|string $handler
@@ -56,7 +56,7 @@ interface RouteCollectionInterface
     public function patch($path, $handler);
 
     /**
-     * Add a route that responds to DELETE HTTP method.
+     * Add a route that responds to DELETE HTTP method
      *
      * @param string          $path
      * @param callable|string $handler
@@ -66,7 +66,7 @@ interface RouteCollectionInterface
     public function delete($path, $handler);
 
     /**
-     * Add a route that responds to HEAD HTTP method.
+     * Add a route that responds to HEAD HTTP method
      *
      * @param string          $path
      * @param callable|string $handler
@@ -76,7 +76,7 @@ interface RouteCollectionInterface
     public function head($path, $handler);
 
     /**
-     * Add a route that responds to OPTIONS HTTP method.
+     * Add a route that responds to OPTIONS HTTP method
      *
      * @param string          $path
      * @param callable|string $handler

--- a/src/RouteConditionHandlerInterface.php
+++ b/src/RouteConditionHandlerInterface.php
@@ -5,66 +5,66 @@ namespace League\Route;
 interface RouteConditionHandlerInterface
 {
     /**
-     * Get the host.
+     * Get the host condition
      *
-     * @return string
+     * @return string|null
      */
     public function getHost() : ?string;
 
     /**
-     * Set the host.
+     * Set the host condition
      *
      * @param string $host
      *
-     * @return \League\Route\RouteConditionHandlerInterface
+     * @return static
      */
     public function setHost(string $host) : RouteConditionHandlerInterface;
 
     /**
-     * Get the name.
+     * Get the route name
      *
-     * @return string
+     * @return string|null
      */
     public function getName() : ?string;
 
     /**
-     * Set the name.
+     * Set the route name
      *
      * @param string $name
      *
-     * @return \League\Route\RouteConditionHandlerInterface
+     * @return static
      */
     public function setName(string $name) : RouteConditionHandlerInterface;
 
     /**
-     * Get the scheme.
+     * Get the scheme condition
      *
-     * @return string
+     * @return string|null
      */
     public function getScheme() : ?string;
 
     /**
-     * Set the scheme.
+     * Set the scheme condition
      *
      * @param string $scheme
      *
-     * @return \League\Route\RouteConditionHandlerInterface
+     * @return static
      */
     public function setScheme(string $scheme) : RouteConditionHandlerInterface;
 
     /**
-     * Get the port.
+     * Get the port condition
      *
-     * @return int
+     * @return int|null
      */
     public function getPort() : ?int;
 
     /**
-     * Set the port.
+     * Set the port condition
      *
      * @param int $port
      *
-     * @return \League\Route\RouteConditionHandlerInterface
+     * @return static
      */
     public function setPort(int $port) : RouteConditionHandlerInterface;
 }

--- a/src/RouteConditionHandlerTrait.php
+++ b/src/RouteConditionHandlerTrait.php
@@ -5,29 +5,27 @@ namespace League\Route;
 trait RouteConditionHandlerTrait
 {
     /**
-     * @var string
+     * @var string|null
      */
     protected $host;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $name;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $scheme;
 
     /**
-     * @var int
+     * @var int|null
      */
     protected $port;
 
     /**
-     * Get the host.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getHost() : ?string
     {
@@ -35,11 +33,7 @@ trait RouteConditionHandlerTrait
     }
 
     /**
-     * Set the host.
-     *
-     * @param string $host
-     *
-     * @return \League\Route\RouteConditionHandlerInterface
+     * {@inheritdoc}
      */
     public function setHost(string $host) : RouteConditionHandlerInterface
     {
@@ -49,9 +43,7 @@ trait RouteConditionHandlerTrait
     }
 
     /**
-     * Get the name.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getName() : ?string
     {
@@ -59,11 +51,7 @@ trait RouteConditionHandlerTrait
     }
 
     /**
-     * Set the name.
-     *
-     * @param string $name
-     *
-     * @return \League\Route\RouteConditionHandlerInterface
+     * {@inheritdoc}
      */
     public function setName(string $name) : RouteConditionHandlerInterface
     {
@@ -73,9 +61,7 @@ trait RouteConditionHandlerTrait
     }
 
     /**
-     * Get the scheme.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getScheme() : ?string
     {
@@ -83,11 +69,7 @@ trait RouteConditionHandlerTrait
     }
 
     /**
-     * Set the scheme.
-     *
-     * @param string $scheme
-     *
-     * @return \League\Route\RouteConditionHandlerInterface
+     * {@inheritdoc}
      */
     public function setScheme(string $scheme) : RouteConditionHandlerInterface
     {
@@ -97,9 +79,7 @@ trait RouteConditionHandlerTrait
     }
 
     /**
-     * Get the port.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     public function getPort() : ?int
     {
@@ -107,11 +87,7 @@ trait RouteConditionHandlerTrait
     }
 
     /**
-     * Set the port.
-     *
-     * @param int $port
-     *
-     * @return \League\Route\RouteConditionHandlerInterface
+     * {@inheritdoc}
      */
     public function setPort(int $port) : RouteConditionHandlerInterface
     {

--- a/src/RouteGroup.php
+++ b/src/RouteGroup.php
@@ -62,7 +62,7 @@ class RouteGroup implements
      */
     public function __invoke() : void
     {
-        call_user_func_array($this->callback, [$this]);
+        ($this->callback)($this);
     }
 
     /**

--- a/src/RouteGroup.php
+++ b/src/RouteGroup.php
@@ -32,11 +32,11 @@ class RouteGroup implements
     protected $prefix;
 
     /**
-     * Constructor.
+     * Constructor
      *
-     * @param string                        $prefix
-     * @param callable                      $callback
-     * @param \League\Route\RouteCollection $collection
+     * @param string                                 $prefix
+     * @param callable                               $callback
+     * @param \League\Route\RouteCollectionInterface $collection
      */
     public function __construct(string $prefix, callable $callback, RouteCollectionInterface $collection)
     {
@@ -46,7 +46,7 @@ class RouteGroup implements
     }
 
     /**
-     * Return the prefix of the group.
+     * Return the prefix of the group
      *
      * @return string
      */
@@ -56,7 +56,7 @@ class RouteGroup implements
     }
 
     /**
-     * Process the group and ensure routes are added to the collection.
+     * Process the group and ensure routes are added to the collection
      *
      * @return void
      */

--- a/src/Router.php
+++ b/src/Router.php
@@ -199,7 +199,7 @@ class Router extends RouteCollector implements
     {
         $this->buildNameIndex();
 
-        if (array_key_exists($name, $this->namedRoutes)) {
+        if (isset($this->namedRoutes[$name])) {
             return $this->namedRoutes[$name];
         }
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -44,7 +44,7 @@ class Router extends RouteCollector implements
     ];
 
     /**
-     * Constructor.
+     * Constructor
      *
      * @param \FastRoute\RouteParser   $parser
      * @param \FastRoute\DataGenerator $generator
@@ -71,7 +71,7 @@ class Router extends RouteCollector implements
     }
 
     /**
-     * Add a group of routes to the collection.
+     * Add a group of routes to the collection
      *
      * @param string   $prefix
      * @param callable $group
@@ -159,7 +159,10 @@ class Router extends RouteCollector implements
     }
 
     /**
-     * Process all groups, and determine if we are using a group's strategy.
+     * Process all groups
+     *
+     * Adds all of the group routes to the collection and determines if the group
+     * strategy should be be used.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request
      *
@@ -184,7 +187,7 @@ class Router extends RouteCollector implements
     }
 
     /**
-     * Get named route.
+     * Get a named route
      *
      * @param string $name
      *
@@ -204,7 +207,7 @@ class Router extends RouteCollector implements
     }
 
     /**
-     * Add a convenient pattern matcher to the internal array for use with all routes.
+     * Add a convenient pattern matcher to the internal array for use with all routes
      *
      * @param string $alias
      * @param string $regex
@@ -222,7 +225,7 @@ class Router extends RouteCollector implements
     }
 
     /**
-     * Convenience method to convert pre-defined key words in to regex strings.
+     * Replace word patterns with regex in route path
      *
      * @param string $path
      *

--- a/src/Strategy/ApplicationStrategy.php
+++ b/src/Strategy/ApplicationStrategy.php
@@ -38,7 +38,7 @@ class ApplicationStrategy implements ContainerAwareInterface, StrategyInterface
     }
 
     /**
-     * Return a middleware that simply throws and exception.
+     * Return a middleware that simply throws an exception
      *
      * @param \Exception $exception
      *

--- a/src/Strategy/ApplicationStrategy.php
+++ b/src/Strategy/ApplicationStrategy.php
@@ -18,7 +18,8 @@ class ApplicationStrategy implements ContainerAwareInterface, StrategyInterface
      */
     public function invokeRouteCallable(Route $route, ServerRequestInterface $request) : ResponseInterface
     {
-        return call_user_func_array($route->getCallable($this->getContainer()), [$request, $route->getVars()]);
+        $controller = $route->getCallable($this->getContainer());
+        return $controller($request, $route->getVars());
     }
 
     /**

--- a/src/Strategy/JsonStrategy.php
+++ b/src/Strategy/JsonStrategy.php
@@ -51,10 +51,11 @@ class JsonStrategy implements ContainerAwareInterface, StrategyInterface
     }
 
     /**
-     * Check if the response can be converted to json
+     * Check if the response can be converted to JSON
+     *
      * Arrays can always be converted, objects can be converted if they're not a response already
      *
-     * @param $response
+     * @param mixed $response
      *
      * @return bool
      */

--- a/src/Strategy/JsonStrategy.php
+++ b/src/Strategy/JsonStrategy.php
@@ -34,7 +34,8 @@ class JsonStrategy implements ContainerAwareInterface, StrategyInterface
      */
     public function invokeRouteCallable(Route $route, ServerRequestInterface $request) : ResponseInterface
     {
-        $response = call_user_func_array($route->getCallable($this->getContainer()), [$request, $route->getVars()]);
+        $controller = $route->getCallable($this->getContainer());
+        $response = $controller($request, $route->getVars());
 
         if ($this->isJsonEncodable($response)) {
             $body     = json_encode($response);

--- a/src/Strategy/JsonStrategy.php
+++ b/src/Strategy/JsonStrategy.php
@@ -86,9 +86,9 @@ class JsonStrategy implements ContainerAwareInterface, StrategyInterface
     }
 
     /**
-     * Return a middleware that simply throws and exception.
+     * Return a middleware the creates a JSON response from an HTTP exception
      *
-     * @param \Exception $exception
+     * @param \League\Route\Http\Exception $exception
      *
      * @return \Psr\Http\Server\MiddlewareInterface
      */

--- a/src/Strategy/StrategyAwareInterface.php
+++ b/src/Strategy/StrategyAwareInterface.php
@@ -5,18 +5,18 @@ namespace League\Route\Strategy;
 interface StrategyAwareInterface
 {
     /**
-     * Set the strategy.
-     *
-     * @param \League\Route\Strategy\StrategyInterface $strategy
-     *
-     * @return \League\Route\Strategy\StrategyAwareInterface
-     */
-    public function setStrategy(StrategyInterface $strategy) : StrategyAwareInterface;
-
-    /**
-     * Gets the strategy.
+     * Get the current strategy
      *
      * @return \League\Route\Strategy\StrategyInterface
      */
     public function getStrategy() : ?StrategyInterface;
+
+    /**
+     * Set the strategy implementation
+     *
+     * @param \League\Route\Strategy\StrategyInterface $strategy
+     *
+     * @return static
+     */
+    public function setStrategy(StrategyInterface $strategy) : StrategyAwareInterface;
 }

--- a/src/Strategy/StrategyAwareTrait.php
+++ b/src/Strategy/StrategyAwareTrait.php
@@ -10,11 +10,7 @@ trait StrategyAwareTrait
     protected $strategy;
 
     /**
-     * Set the strategy.
-     *
-     * @param \League\Route\Strategy\StrategyInterface $strategy
-     *
-     * @return \League\Route\Strategy\StrategyAwareInterface
+     * {@inheritdoc}
      */
     public function setStrategy(StrategyInterface $strategy) : StrategyAwareInterface
     {
@@ -24,9 +20,7 @@ trait StrategyAwareTrait
     }
 
     /**
-     * Gets the strategy.
-     *
-     * @return \League\Route\Strategy\StrategyInterface
+     * {@inheritdoc}
      */
     public function getStrategy() : ?StrategyInterface
     {

--- a/src/Strategy/StrategyInterface.php
+++ b/src/Strategy/StrategyInterface.php
@@ -11,7 +11,7 @@ use Psr\Http\Server\MiddlewareInterface;
 interface StrategyInterface
 {
     /**
-     * Invoke the route callable based on the strategy.
+     * Invoke the route callable based on the strategy
      *
      * @param \League\Route\Route                      $route
      * @param \Psr\Http\Message\ServerRequestInterface $request
@@ -32,15 +32,17 @@ interface StrategyInterface
     /**
      * Get a middleware that will decorate a NotAllowedException
      *
-     * @param \League\Route\Http\Exception\NotFoundException $exception
+     * @param \League\Route\Http\Exception\MethodNotAllowedException $exception
      *
      * @return \Psr\Http\Server\MiddlewareInterface
      */
     public function getMethodNotAllowedDecorator(MethodNotAllowedException $exception) : MiddlewareInterface;
 
     /**
-     * Get a middleware that acts as an exception handler, it should wrap the rest of the
-     * middleware stack and catch eny exceptions.
+     * Get a middleware that will act as an exception handler
+     *
+     * The middleware must wrap the rest of the middleware stack and catch any
+     * thrown exceptions.
      *
      * @return \Psr\Http\Server\MiddlewareInterface
      */

--- a/tests/Asset/function.php
+++ b/tests/Asset/function.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ServerRequestInterface;
  *
  * @return \Psr\Http\Message\ResponseInterface
  */
-function namedFunctionCallable(ServerRequestInterface $request, ResponseInterface $response) {
+function namedFunctionCallable(ServerRequestInterface $request, ResponseInterface $response)
+{
     return $response;
 }


### PR DESCRIPTION
Mostly documentation changes around:

- phpdoc titles are not sentences
- phpdoc typos and grammar
- phpdoc expansion for clarity

A couple of very minor optimizations around the usage of `call_user_func_array` and array key checking.

More complete configuration of phpcs, and a phpcs violation fix in test code.