### PR TITLE
Set correct test namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,9 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "League\\Route\\Test\\": "tests"
+            "League\\Route\\": "tests"
         },
-        "files": ["tests/Asset/function.php"]
+        "files": ["tests/Fixture/function.php"]
     },
     "extra": {
         "branch-alias": {

--- a/tests/DispatchIntegrationTest.php
+++ b/tests/DispatchIntegrationTest.php
@@ -4,7 +4,6 @@ namespace League\Route;
 
 use Exception;
 use League\Route\Http\Exception\{BadRequestException, MethodNotAllowedException, NotFoundException};
-use League\Route\Router;
 use League\Route\Strategy\JsonStrategy;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\{

--- a/tests/Fixture/Controller.php
+++ b/tests/Fixture/Controller.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Route\Test\Asset;
+namespace League\Route\Fixture;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/tests/Fixture/function.php
+++ b/tests/Fixture/function.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Route\Test\Asset;
+namespace League\Route\Fixture;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/tests/RouteGroupTest.php
+++ b/tests/RouteGroupTest.php
@@ -2,7 +2,6 @@
 
 namespace League\Route;
 
-use League\Route\RouteGroup;
 use PHPUnit\Framework\TestCase;
 
 class RouteGroupTest extends TestCase

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -3,7 +3,7 @@
 namespace League\Route;
 
 use InvalidArgumentException;
-use League\Route\Test\Asset\Controller;
+use League\Route\Fixture\Controller;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
@@ -42,7 +42,7 @@ class RouteTest extends TestCase
      */
     public function testRouteSetsAndResolvesNamedFunctionCallable() : void
     {
-        $callable = 'League\Route\Test\Asset\namedFunctionCallable';
+        $callable = 'League\Route\Fixture\namedFunctionCallable';
         $route    = new Route('GET', '/', $callable);
         $this->assertTrue(is_callable($route->getCallable()));
     }
@@ -70,7 +70,7 @@ class RouteTest extends TestCase
             ->will($this->returnValue(new Controller))
         ;
 
-        $callable = 'League\Route\Test\Asset\Controller::action';
+        $callable = 'League\Route\Fixture\Controller::action';
         $route    = new Route('GET', '/', $callable);
 
         $newCallable = $route->getCallable($container);
@@ -98,7 +98,7 @@ class RouteTest extends TestCase
             ->will($this->returnValue(false))
         ;
 
-        $callable = 'League\Route\Test\Asset\Controller::action';
+        $callable = 'League\Route\Fixture\Controller::action';
         $route    = new Route('GET', '/', $callable);
 
         $newCallable = $route->getCallable($container);


### PR DESCRIPTION
Based on every written test, the expected namespace is `League\Route` not `League\Route\Test`.

Renamed `Asset` to `Fixture` because it is a more commonly understood name for testing support code.
