### PR TITLE
Fix method signature to return null and added tests

### DIFF
--- a/src/Middleware/MiddlewareAwareInterface.php
+++ b/src/Middleware/MiddlewareAwareInterface.php
@@ -38,7 +38,7 @@ interface MiddlewareAwareInterface
      *
      * @return \Psr\Http\Server\MiddlewareInterface|null
      */
-    public function shiftMiddleware() : MiddlewareInterface;
+    public function shiftMiddleware() : ?MiddlewareInterface;
 
     /**
      * Get the stack of middleware

--- a/src/Middleware/MiddlewareAwareTrait.php
+++ b/src/Middleware/MiddlewareAwareTrait.php
@@ -46,7 +46,7 @@ trait MiddlewareAwareTrait
     /**
      * {@inheritdoc}
      */
-    public function shiftMiddleware() : MiddlewareInterface
+    public function shiftMiddleware() : ?MiddlewareInterface
     {
         return array_shift($this->middleware);
     }

--- a/tests/Middleware/MiddlewareAwareTraitTest.php
+++ b/tests/Middleware/MiddlewareAwareTraitTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace League\Route\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class MiddlewareAwareTraitTest extends TestCase
+{
+    public function testShiftMiddleware()
+    {
+        $middlewareAwareClass = new class implements MiddlewareAwareInterface
+        {
+            use MiddlewareAwareTrait;
+        };
+
+        $middlewareA = new class implements MiddlewareInterface
+        {
+            public function process(
+                ServerRequestInterface $request,
+                RequestHandlerInterface $handler
+            ): ResponseInterface {
+            }
+        };
+
+        $middlewareB = clone $middlewareA;
+
+        $middlewareAwareClass->middlewares([$middlewareA, $middlewareB]);
+
+        TestCase::assertEquals($middlewareA, $middlewareAwareClass->shiftMiddleware());
+        TestCase::assertEquals($middlewareB, $middlewareAwareClass->shiftMiddleware());
+        TestCase::assertNull($middlewareAwareClass->shiftMiddleware());
+    }
+}


### PR DESCRIPTION
[The statement](https://github.com/thephpleague/route/blob/master/src/Dispatcher.php#L57) is never reached due to wrong type return, and instead will raise an internal php error.

This PR intends to fix that.