### PR TITLE
Minor wording fix in documentation

### DIFF
--- a/docs/4.x/usage.md
+++ b/docs/4.x/usage.md
@@ -102,7 +102,7 @@ $response = $router->dispatch($request);
 (new Zend\Diactoros\Response\SapiEmitter)->emit($response);
 ~~~
 
-The code above will turn your returned array in to a JSON response.
+The code above will convert your returned array in to a JSON response.
 
 ~~~json
 {

--- a/docs/4.x/usage.md
+++ b/docs/4.x/usage.md
@@ -102,7 +102,7 @@ $response = $router->dispatch($request);
 (new Zend\Diactoros\Response\SapiEmitter)->emit($response);
 ~~~
 
-The code above will build turn your returned array in to a JSON response.
+The code above will turn your returned array in to a JSON response.
 
 ~~~json
 {


### PR DESCRIPTION
Remove redundant verb 'build'.

Aside, the README directs developers to the `gh-pages` branch for documentation edits, which does not appear to exist.