### PR TITLE
Dispatcher::dispatchRequest: Ensure matching handlers are Route objects

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -28,7 +28,9 @@ class Dispatcher extends GroupCountBasedDispatcher implements
      */
     public function dispatchRequest(ServerRequestInterface $request) : ResponseInterface
     {
-        $match = $this->dispatch($request->getMethod(), $request->getUri()->getPath());
+        $httpMethod = $request->getMethod();
+        $uri = $request->getUri()->getPath();
+        $match = $this->dispatch($httpMethod, $uri);
 
         switch ($match[0]) {
             case FastRoute::NOT_FOUND:
@@ -39,12 +41,30 @@ class Dispatcher extends GroupCountBasedDispatcher implements
                 $this->setMethodNotAllowedDecoratorMiddleware($allowed);
                 break;
             case FastRoute::FOUND:
-                $match[1]->setVars($match[2]);
-                $this->setFoundMiddleware($match[1]);
+                $route = $this->ensureHandlerIsRoute($match[1], $httpMethod, $uri)->setVars($match[2]);
+                $this->setFoundMiddleware($route);
                 break;
         }
 
         return $this->handle($request);
+    }
+
+    /**
+     * Ensure handler is a Route, honoring the contract of dispatchRequest.
+     *
+     * @param Route|mixed $matchingHandler
+     * @param string $httpMethod
+     * @param string $uri
+     *
+     * @return Route
+     *
+     */
+    private function ensureHandlerIsRoute($matchingHandler, $httpMethod, $uri) : Route
+    {
+        if (is_a($matchingHandler, Route::class)) {
+            return $matchingHandler;
+        }
+        return new Route($httpMethod, $uri, $matchingHandler);
     }
 
     /**

--- a/tests/DispatchIntegrationTest.php
+++ b/tests/DispatchIntegrationTest.php
@@ -901,4 +901,48 @@ class DispatchIntegrationTest extends TestCase
 
         $router->dispatch($request);
     }
+
+    public function testDispatchDoesNotThrowWhenUsingAddRoute()
+    {
+        $request  = $this->createMock(ServerRequestInterface::class);
+        $response = $this->createMock(ResponseInterface::class);
+        $uri      = $this->createMock(UriInterface::class);
+
+        $uri
+            ->expects($this->exactly(2))
+            ->method('getPath')
+            ->will($this->returnValue('/example/route'))
+        ;
+
+        $request
+            ->expects($this->once())
+            ->method('getMethod')
+            ->will($this->returnValue('GET'))
+        ;
+
+        $request
+            ->expects($this->exactly(2))
+            ->method('getUri')
+            ->will($this->returnValue($uri))
+        ;
+
+        $router = new Router;
+
+        $router->addRoute(['GET', 'POST'], '/example/{something}', function (
+            ServerRequestInterface $request,
+            array $args
+        ) use (
+            $response
+        ) : ResponseInterface {
+            $this->assertSame([
+                'something' => 'route'
+            ], $args);
+
+            return $response;
+        });
+
+        $returnedResponse = $router->dispatch($request);
+
+        $this->assertSame($response, $returnedResponse);
+    }
 }


### PR DESCRIPTION
Background:

There seems to be an implicit contract in `League\Route\Dispatcher::dispatchRequest`
that match[1] (the handler) is a `League\Route\Route` (as it calls [setVars](https://github.com/thephpleague/route/blob/4.2.0/src/Dispatcher.php#L42))

This throws when the route is created via `Router::addRoute`, because now $match[1] will be a `callable|mixed|Closure etc`.

A possible solution is to ensure that the matching handler is a Router. 

Other things to consider: 

Maybe using `Router::addRoute` should be avoided. Reasons:

- It is not possible for to add middleware when calling addRoute directly.
- It doesn't add any route in the routes array, as it is the parent class method.