### PR TITLE
Updated to use zendframework/zend-httphandlerrunner

### DIFF
--- a/docs/4.x/usage.md
+++ b/docs/4.x/usage.md
@@ -23,6 +23,11 @@ Next, install an implementation of PSR-7. We recommend the [Zend Diactoros proje
 ~~~
 composer require zendframework/zend-diactoros
 ~~~
+If you use [Zend Diactoros project][diactoros] you will also need
+
+~~~
+composer require zendframework/zend-httphandlerrunner
+~~~
 
 Optionally, you could also install a PSR-11 dependency injection container, see [Dependency Injection](/4.x/dependency-injection) for more information.
 
@@ -58,7 +63,7 @@ $router->map('GET', '/', function (ServerRequestInterface $request) : ResponseIn
 $response = $router->dispatch($request);
 
 // send the response to the browser
-(new Zend\Diactoros\Response\SapiEmitter)->emit($response);
+(new Zend\HttpHandlerRunner\Emitter\SapiEmitter)->emit($response);
 ~~~
 
 ## APIs
@@ -99,7 +104,7 @@ $router->map('GET', '/', function (ServerRequestInterface $request) : array {
 $response = $router->dispatch($request);
 
 // send the response to the browser
-(new Zend\Diactoros\Response\SapiEmitter)->emit($response);
+(new Zend\HttpHandlerRunner\Emitter\SapiEmitter)->emit($response);
 ~~~
 
 The code above will convert your returned array in to a JSON response.


### PR DESCRIPTION
Emitters are deprecated from Diactoros starting with version 1.8.0