### PR TITLE
Fix typo in example call to add middleware in docs

### DIFF
--- a/docs/4.x/middleware.md
+++ b/docs/4.x/middleware.md
@@ -87,7 +87,7 @@ $router
     ->group('/admin', function ($router) {
         // ... add routes
     })
-    ->middle(new Acme\AuthMiddleware)
+    ->middleware(new Acme\AuthMiddleware)
 ;
 ~~~
 


### PR DESCRIPTION
The example call to `middle()` in the docs should be `middleware()`.