### PR TITLE
Add prefix to Route's path when setting a parent group

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -158,6 +158,12 @@ class Route implements
     public function setParentGroup(RouteGroup $group) : self
     {
         $this->group = $group;
+        $prefix = $group->getPrefix();
+        $path = $this->getPath();
+        if (strcmp($prefix, substr($path, 0, strlen($prefix))) != 0) {
+            $path = $prefix . $path;
+            $this->path = $path;
+        }
 
         return $this;
     }

--- a/src/Router.php
+++ b/src/Router.php
@@ -97,10 +97,14 @@ class Router extends RouteCollector implements
 
         $this->prepRoutes($request);
 
-        return (new Dispatcher($this->getData()))
-            ->middlewares($this->getMiddlewareStack())
-            ->setStrategy($this->getStrategy())
-            ->dispatchRequest($request)
+        $data = $this->getData();
+        $dispatcher= new Dispatcher($data);
+        $dispatcher->middlewares($this->getMiddlewareStack());
+        $dispatcher->setStrategy($this->getStrategy());
+        $response = $dispatcher->dispatchRequest($request);
+
+        return ($response);
+
         ;
     }
 


### PR DESCRIPTION
If you  call `map()` on the group, it prepends the prefix to the paths defined.
However, if you add a group to a route through calling `setParentGroup($group)`, it fails to do so. This pull request remedies that.