### PR TITLE
fix deadlink.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following versions of PHP are supported by this version.
 
 Route has [full documentation](http://route.thephpleague.com), powered by [Jekyll](http://jekyllrb.com/).
 
-Contribute to this documentation in the [gh-pages branch](https://github.com/thephpleague/route/tree/gh-pages/).
+Contribute to this documentation in the [docs directory](https://github.com/thephpleague/route/tree/master/docs/).
 
 ## Testing
 

--- a/docs/4.x/controllers.md
+++ b/docs/4.x/controllers.md
@@ -266,4 +266,4 @@ $router->map('GET', '/', 'Acme\controller');
 
 ## Dependency Injection
 
-Where Route is instantiating the objects for your defined controller, a dependency injection container can be used to resolve those objects. Read more on dependency injection [here](/docs/4.x/dependency-injection/).
+Where Route is instantiating the objects for your defined controller, a dependency injection container can be used to resolve those objects. Read more on dependency injection [here](/4.x/dependency-injection/).


### PR DESCRIPTION
I just fixed 2 dead links in the docs and README.
There is no `gh-pages` branch, so I changed it to `docs directory`. If you have more better link, please change it. 