### PR TITLE
Update supported php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 7.1
     - 7.2
     - 7.3
     - 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - 7.4
 
 env:
   - COMPOSER_OPTS=""

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following versions of PHP are supported by this version.
 * PHP 7.1
 * PHP 7.2
 * PHP 7.3
+* PHP 7.4
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^9.0",
+        "phpunit/phpunit" : "^8.5",
         "squizlabs/php_codesniffer": "^3.3",
         "phpstan/phpstan": "^0.10.3",
         "phpstan/phpstan-phpunit": "^0.10.0"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^7.0",
+        "phpunit/phpunit" : "^8.2",
         "squizlabs/php_codesniffer": "^3.3",
         "phpstan/phpstan": "^0.10.3",
         "phpstan/phpstan-phpunit": "^0.10.0"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^8.2",
+        "phpunit/phpunit" : "^9.0",
         "squizlabs/php_codesniffer": "^3.3",
         "phpstan/phpstan": "^0.10.3",
         "phpstan/phpstan-phpunit": "^0.10.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,7 +23,6 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
         <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,9 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
+    <php>
+        <ini name="error_reporting" value="E_ALL"/>
+    </php>
     <testsuites>
         <testsuite name="League Test Suite">
             <directory>tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,7 @@
         </whitelist>
     </filter>
     <logging>
+        <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
         <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -20,7 +20,7 @@ class RouteTest extends TestCase
     {
         $callable = new Controller;
         $route    = new Route('GET', '/', $callable);
-        $this->assertInternalType('callable', $route->getCallable());
+        $this->assertIsCallable($route->getCallable());
     }
 
     /**
@@ -32,7 +32,7 @@ class RouteTest extends TestCase
     {
         $callable = [new Controller, 'action'];
         $route    = new Route('GET', '/', $callable);
-        $this->assertInternalType('callable', $route->getCallable());
+        $this->assertIsCallable($route->getCallable());
     }
 
     /**
@@ -44,7 +44,7 @@ class RouteTest extends TestCase
     {
         $callable = 'League\Route\Fixture\namedFunctionCallable';
         $route    = new Route('GET', '/', $callable);
-        $this->assertInternalType('callable', $route->getCallable());
+        $this->assertIsCallable($route->getCallable());
     }
 
     /**

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -87,9 +87,14 @@ class RouterTest extends TestCase
      */
     public function testNewPatternMatchesCanBeAddedAtRuntime(): void
     {
-        $router = new Router;
+        $router = new class extends Router {
+            public function getPatternMatchers(): array
+            {
+                return $this->patternMatchers;
+            }
+        };
         $router->addPatternMatcher('mockMatcher', '[a-zA-Z]');
-        $matchers = $this->getObjectAttribute($router, 'patternMatchers');
+        $matchers = $router->getPatternMatchers();
 
         $this->assertArrayHasKey('/{(.+?):mockMatcher}/', $matchers);
         $this->assertEquals('{$1:[a-zA-Z]}', $matchers['/{(.+?):mockMatcher}/']);


### PR DESCRIPTION
I want to try use Route, but my company need php 7.4 supporting. 

Changes: 
- update phpunit to 8.5 - this version compatible with 7.2-7.4
- fix deprecations
- 7.1 removed (it is dead: https://www.php.net/supported-versions.php)