### PR TITLE
ContainerAwareInterface update

### DIFF
--- a/src/ContainerAwareInterface.php
+++ b/src/ContainerAwareInterface.php
@@ -3,8 +3,9 @@
 namespace League\Route;
 
 use Psr\Container\ContainerInterface;
+use League\Route\Strategy\StrategyInterface;
 
-interface ContainerAwareInterface
+interface ContainerAwareInterface extends StrategyInterface
 {
     /**
      * Get the current container


### PR DESCRIPTION
I was using league/route with league/container and I've notice a problem with interfaces when setting a container to the the strategy variable. Something like this ->
![image](https://user-images.githubusercontent.com/49328570/77448515-ab6e1e80-6dcf-11ea-867d-27efdcc38d97.png)

After opening a github issue I felt free to create a fork and make this simple PR to change that line which was bugging the implementation of the libs. I don't know if it's the best solution but worked for me. 

Peace.
