### PR TITLE
Support psr/container 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "nikic/fast-route": "^1.3",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0|^2.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0.1",
         "psr/http-server-handler": "^1.0.1",


### PR DESCRIPTION
Problem 1
    - league/route is locked to version 5.0.0 and an update of this package was not requested.
    - league/route 5.0.0 requires psr/container ^1.0 -> found psr/container[1.0.0, 1.1.0, 1.1.1] but it conflicts with your root composer.json require (^2.0).