### PR TITLE
Update internal links in 5.x docs to point to the same version

### DIFF
--- a/docs/5.x/controllers.md
+++ b/docs/5.x/controllers.md
@@ -9,9 +9,9 @@ sections:
 ---
 ## Introduction
 
-Every defined route requires a `callable` to invoke when dispatched, something that could be described as a controller in MVC. By default, Route only imposes that the callable is defined with a specific signature, it is given a request object as the first argument, an associative array of wildcard route arguments as the second argument, and expects a response object to be returned. Read more about this in [HTTP](/4.x/http).
+Every defined route requires a `callable` to invoke when dispatched, something that could be described as a controller in MVC. By default, Route only imposes that the callable is defined with a specific signature, it is given a request object as the first argument, an associative array of wildcard route arguments as the second argument, and expects a response object to be returned. Read more about this in [HTTP](/5.x/http).
 
-This behaviour can be changed by creating/using a different strategy, read more about strategies [here](/4.x/strategies).
+This behaviour can be changed by creating/using a different strategy, read more about strategies [here](/5.x/strategies).
 
 ## Defining Controllers
 
@@ -266,4 +266,4 @@ $router->map('GET', '/', 'Acme\controller');
 
 ## Dependency Injection
 
-Where Route is instantiating the objects for your defined controller, a dependency injection container can be used to resolve those objects. Read more on dependency injection [here](/4.x/dependency-injection/).
+Where Route is instantiating the objects for your defined controller, a dependency injection container can be used to resolve those objects. Read more on dependency injection [here](/5.x/dependency-injection/).

--- a/docs/5.x/http.md
+++ b/docs/5.x/http.md
@@ -47,7 +47,7 @@ class SomeMiddleware implements MiddlewareInterface
 }
 ~~~
 
-Read more about middleware [here](/4.x/middleware).
+Read more about middleware [here](/5.x/middleware).
 
 ### Controller Signature
 
@@ -63,7 +63,7 @@ function controller(ServerRequestInterface $request) {
 }
 ~~~
 
-See more about controllers [here](/4.x/controllers).
+See more about controllers [here](/5.x/controllers).
 
 ### Request Input
 
@@ -73,7 +73,7 @@ Route does not provide any functionality for dealing with globals such as `$_GET
 
 Because Route is built around PSR-15, this means that middleware and controllers are handles in a [single pass](https://www.php-fig.org/psr/psr-15/meta/#52-single-pass-lambda) approach. What this means in practice is that all middleware is passed a request object but is expected to build and return its own response or pass off to the next middleware in the stack for that to create one. Any controller that is dispatched via Route is wrapped in a middleware that adheres to this.
 
-Once wrapped, your controller ultimately becomes the last middleware in the stack (this does not mean that it has to be invoked last, see [middleware](/4.x/middleware) for more on this), it just means that it will only be concerned with creating and returning a response object.
+Once wrapped, your controller ultimately becomes the last middleware in the stack (this does not mean that it has to be invoked last, see [middleware](/5.x/middleware) for more on this), it just means that it will only be concerned with creating and returning a response object.
 
 An example of a controller building a response might look like this.
 

--- a/docs/5.x/usage.md
+++ b/docs/5.x/usage.md
@@ -29,7 +29,7 @@ If you use [Laminas Diactoros project][diactoros] you will also need
 composer require laminas/laminas-httphandlerrunner
 ~~~
 
-Optionally, you could also install a PSR-11 dependency injection container, see [Dependency Injection](/4.x/dependency-injection) for more information.
+Optionally, you could also install a PSR-11 dependency injection container, see [Dependency Injection](/5.x/dependency-injection) for more information.
 
 ~~~
 composer require league/container


### PR DESCRIPTION
Some of the internal links in the 5.x docs still pointed to the 4.x
docs, so users will jump between versions - possibly without realising -
when browsing them on the web.