### PR TITLE
Use Laminas Dictoros instead of Zend in 5.x docs

### DIFF
--- a/docs/5.x/dependency-injection.md
+++ b/docs/5.x/dependency-injection.md
@@ -27,7 +27,7 @@ namespace Acme;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Diactoros\Response;
+use Laminas\Diactoros\Response;
 
 class SomeController
 {

--- a/docs/5.x/http.md
+++ b/docs/5.x/http.md
@@ -12,7 +12,7 @@ HTTP messages form the core of any modern web application. Route is built with t
 
 We also make use of [PSR-15](https://www.php-fig.org/psr/psr-15/) request handlers and middleware.
 
-Throughout this documentation, we will be using [zend-diactoros](https://zendframework.github.io/zend-diactoros/) to provide our HTTP messages but any implementation is supported.
+Throughout this documentation, we will be using [laminas-diactoros](https://docs.laminas.dev/laminas-diactoros/) to provide our HTTP messages but any implementation is supported.
 
 ## The Request
 
@@ -82,7 +82,7 @@ An example of a controller building a response might look like this.
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Diactoros\Response;
+use Laminas\Diactoros\Response;
 
 function controller(ServerRequestInterface $request): ResponseInterface {
     $response = new Response;

--- a/docs/5.x/middleware.md
+++ b/docs/5.x/middleware.md
@@ -32,7 +32,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\RedirectResponse;
+use Laminas\Diactoros\Response\RedirectResponse;
 
 class AuthMiddleware implements MiddlewareInterface
 {

--- a/docs/5.x/strategies.md
+++ b/docs/5.x/strategies.md
@@ -93,7 +93,7 @@ $router
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Diactoros\Response;
+use Laminas\Diactoros\Response;
 
 function controller(ServerRequestInterface $request, array $args): ResponseInterface {
     // ...
@@ -111,7 +111,7 @@ The application strategy simply allows any `Throwable` to bubble out, you can ca
 
 `League\Route\Strategy\JsonStrategy` aims to make building JSON APIs a little easier. It provides a PSR-7 `Psr\Http\Message\ServerRequestInterface` implementation and any route arguments to the controller as with the application strategy, the difference being that you can either build and return a response yourself or return an array or object, and a JSON response will be built for you.
 
-To make use of the JSON strategy, you will need to provide it with a [PSR-17](https://www.php-fig.org/psr/psr-17/) response factory implementation. Some examples of HTTP Factory packages can be found [here](https://github.com/http-interop?utf8=%E2%9C%93&q=http-factory&type=&language=). We will use the `zend-diactoros` factory as an example.
+To make use of the JSON strategy, you will need to provide it with a [PSR-17](https://www.php-fig.org/psr/psr-17/) response factory implementation. Some examples of HTTP Factory packages can be found [here](https://github.com/http-interop?utf8=%E2%9C%93&q=http-factory&type=&language=). We will use the `laminas-diactoros` factory as an example.
 
 ~~~php
 <?php declare(strict_types=1);
@@ -129,7 +129,7 @@ $router = (new League\Route\Router)->setStrategy($strategy);
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Diactoros\Response;
+use Laminas\Diactoros\Response;
 
 function responseController(ServerRequestInterface $request, array $args): ResponseInterface {
     // ...


### PR DESCRIPTION
Some parts of the 5.x docs refer to Laminas, others to Zend. This
switches them all to Laminas for consistency, as Zend is no longer
maintained.