### PR TITLE
Named routes within RouteGroups

### DIFF
--- a/docs/5.x/routes.md
+++ b/docs/5.x/routes.md
@@ -111,6 +111,25 @@ GET /admin/acme/route2
 GET /admin/acme/route3
 ~~~
 
+### Named Routes
+
+Named routes helps when you want to retrieve a Route by a human friendly label. 
+
+~~~php
+<?php declare(strict_types=1);
+
+$router = new League\Route\Router;
+$request = new Request; // Psr/Http/Message/ServerRequestInterface
+
+$router->group('/admin', function (\League\Route\RouteGroup $route) {
+    $route->map('GET', '/acme/route1', 'AcmeController::actionOne')->setName('actionOne');
+    $route->map('GET', '/acme/route2', 'AcmeController::actionTwo')->setName('actionTwo');
+});
+
+$route = $router->getNamedRoute('actionOne');
+$route->getPath(); // "/admin/acme/route1"
+~~~
+
 ### Conditions
 
 As mentioned above, route conditions can be applied to a group and will be matched across all routes contained in that group, specific routes within the group can override this functionality as displayed below.

--- a/src/Router.php
+++ b/src/Router.php
@@ -111,6 +111,10 @@ class Router implements
 
     public function getNamedRoute(string $name): Route
     {
+        if (!$this->routesPrepared) {
+            $this->collectGroupRoutes();
+        }
+
         $this->buildNameIndex();
 
         if (isset($this->namedRoutes[$name])) {
@@ -219,6 +223,13 @@ class Router implements
             }
 
             $this->routeCollector->addRoute($route->getMethod(), $this->parseRoutePath($route->getPath()), $route);
+        }
+    }
+
+    protected function collectGroupRoutes(): void
+    {
+        foreach ($this->groups as $key => $group) {
+            $group();
         }
     }
 

--- a/tests/RouteGroupTest.php
+++ b/tests/RouteGroupTest.php
@@ -138,4 +138,22 @@ class RouteGroupTest extends TestCase
 
         $group();
     }
+
+    public function testGroupWithNamedRoutes(): void
+    {
+        $router = new Router();
+        $name   = 'route';
+        $expected = null;
+
+        $router->group('/acme', function (RouteGroup $group) use ($name, &$expected) {
+            $expected = $group->get('/route', function () {
+            })
+            ->setName($name);
+        });
+
+        $actual = $router->getNamedRoute($name);
+
+        $this->assertNotNull($actual);
+        $this->assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
Found an issue where you couldn't fetch a named route which was declared within a `RouteGroup`.

```php
$router->group('/admin', function (\League\Route\RouteGroup $route) {
    $route->map('GET', '/acme/route1', 'AcmeController::actionOne')->setName('actionOne');
    $route->map('GET', '/acme/route2', 'AcmeController::actionTwo')->setName('actionTwo');
});

$router->getNamedRoute('actionOne'); // Throws an InvalidArgumentException
````
* Added a unit test to reproduce the error
* Added a fix where the getNamedRoute method collects all group routes, if needed
* Added a doc note regarding this (Ref #287)