### PR TITLE
Add an option to get the target route from the middleware

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -38,12 +38,8 @@ class Dispatcher extends GroupCountBasedDispatcher implements
                 $this->setMethodNotAllowedDecoratorMiddleware($allowed);
                 break;
             case FastRoute::FOUND:
-                $strategy = $match[1]->getStrategy();
-                $container = $strategy instanceof ContainerAwareInterface ? $strategy->getContainer() : null;
                 $route = $this->ensureHandlerIsRoute($match[1], $method, $uri)->setVars(
-                    array_merge($match[2], [
-                        'routeTarget' => $match[1]->getCallable($container)
-                    ])
+                    array_merge($match[2], ['routeTarget' => $match[1]->getRouteTarget()])
                 );
                 
                 if ($this->isExtraConditionMatch($route, $request)) {

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -38,8 +38,14 @@ class Dispatcher extends GroupCountBasedDispatcher implements
                 $this->setMethodNotAllowedDecoratorMiddleware($allowed);
                 break;
             case FastRoute::FOUND:
-                $route = $this->ensureHandlerIsRoute($match[1], $method, $uri)->setVars($match[2]);
-
+                $strategy = $match[1]->getStrategy();
+                $container = $strategy instanceof ContainerAwareInterface ? $strategy->getContainer() : null;
+                $route = $this->ensureHandlerIsRoute($match[1], $method, $uri)->setVars(
+                    array_merge($match[2], [
+                        'routeTarget' => $match[1]->getCallable($container)
+                    ])
+                );
+                
                 if ($this->isExtraConditionMatch($route, $request)) {
                     $this->setFoundMiddleware($route);
                     $request = $this->requestWithRouteAttributes($request, $route);

--- a/src/Route.php
+++ b/src/Route.php
@@ -198,4 +198,17 @@ class Route implements
 
         return $class;
     }
+        
+    public function getRouteTarget(): string
+    {
+        $target = $this->handler;
+
+        if (is_string($target)) {
+            return $target;
+        } elseif (is_array($target) && isset($target[0]) && is_string($target[0]) && isset($target[1]) && is_string($target[1])) {
+            return $target[0]. '::'. $target[1];
+        } else {
+            return '';
+        }    
+    }
 }


### PR DESCRIPTION
Please add an option to get the target route from the middleware, this is necessary to implement authorization in the API when the JWT token contains the user role, and valid permissions for roles are loaded from the configuration.

I think it is wrong to pass the check to the controller

And it also seems strange that middleware does not know for what purpose it is being executed.