### PR TITLE
Fix psr/simple-cache version constraint. Fixes #320

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "psr/http-server-handler": "^1.0.1",
         "psr/http-server-middleware": "^1.0.1",
         "opis/closure": "^3.5.5",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "laminas/laminas-diactoros": "^2.3",


### PR DESCRIPTION
Widen psr/simple-cache version constraint to support 1.0|2.0|3.0.
Fixes #320