### PR TITLE
Drop support for PHP 7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.2
+                  php-version: 8.0
                   extensions: curl, mbstring
                   coverage: none
                   tools: composer:v2, cs2pr
@@ -27,16 +27,13 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: ['7.2', '7.3', '7.4']
+                php: ['8.0', '8.1', '8.2']
                 coverage: [true]
                 composer-flags: ['']
                 include:
                     - php: '8.0'
                       coverage: false
                       composer-flags: '--ignore-platform-req=php'
-                    - php: '7.2'
-                      coverage: false
-                      composer-flags: '--prefer-lowest'
 
         steps:
             - uses: actions/checkout@v2
@@ -51,10 +48,6 @@ jobs:
                   tools: composer:v2
 
             - run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-            - name: "Use PHPUnit 9.3+ on PHP 8"
-              run: composer require --no-update --dev phpunit/phpunit:^9.3
-              if: "matrix.php == '8.0'"
 
             - run: composer update --no-progress ${{ matrix.composer-flags }}
 
@@ -76,7 +69,7 @@ jobs:
 
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.2
+                  php-version: 8.0
                   extensions: curl, mbstring
                   coverage: none
                   tools: composer:v2

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.0",
         "nikic/fast-route": "^1.3",
         "psr/container": "^1.0|^2.0",
         "psr/http-factory": "^1.0",
@@ -29,12 +29,12 @@
         "psr/http-server-handler": "^1.0.1",
         "psr/http-server-middleware": "^1.0.1",
         "opis/closure": "^3.5.5",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^2.0|^3.0"
     },
     "require-dev": {
         "laminas/laminas-diactoros": "^2.3",
-        "phpstan/phpstan": "^0.12",
-        "phpstan/phpstan-phpunit": "^0.12",
+        "phpstan/phpstan": "^1.9",
+        "phpstan/phpstan-phpunit": "^1.3",
         "phpunit/phpunit": "^8.5",
         "roave/security-advisories": "dev-master",
         "scrutinizer/ocular": "^1.8",

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -8,23 +8,11 @@ use Psr\SimpleCache\CacheInterface;
 
 class FileCache implements CacheInterface
 {
-    /**
-     * @var string
-     */
-    protected $cacheFilePath;
-
-    /**
-     * @var integer
-     */
-    protected $ttl;
-
-    public function __construct(string $cacheFilePath, int $ttl)
+    public function __construct(protected string $cacheFilePath, protected int $ttl)
     {
-        $this->cacheFilePath = $cacheFilePath;
-        $this->ttl = $ttl;
     }
 
-    public function get($key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
         return ($this->has($key)) ? file_get_contents($this->cacheFilePath) : $default;
     }

--- a/src/Cache/Router.php
+++ b/src/Cache/Router.php
@@ -26,26 +26,11 @@ class Router
      */
     protected $builder;
 
-    /**
-     * @var CacheInterface
-     */
-    protected $cache;
+    protected int $ttl;
 
-    /**
-     * @var integer
-     */
-    protected $ttl;
-
-    /**
-     * @var bool
-     */
-    protected $cacheEnabled;
-
-    public function __construct(callable $builder, CacheInterface $cache, bool $cacheEnabled = true)
+    public function __construct(callable $builder, protected CacheInterface $cache, protected bool $cacheEnabled = true)
     {
         $this->builder = $builder;
-        $this->cache = $cache;
-        $this->cacheEnabled = $cacheEnabled;
     }
 
     public function dispatch(ServerRequestInterface $request): ResponseInterface

--- a/src/ContainerAwareTrait.php
+++ b/src/ContainerAwareTrait.php
@@ -9,10 +9,7 @@ use RuntimeException;
 
 trait ContainerAwareTrait
 {
-    /**
-     * @var ?ContainerInterface
-     */
-    protected $container;
+    protected ?ContainerInterface $container = null;
 
     public function getContainer(): ?ContainerInterface
     {

--- a/src/Http/Exception.php
+++ b/src/Http/Exception.php
@@ -9,32 +9,13 @@ use Psr\Http\Message\ResponseInterface;
 
 class Exception extends \Exception implements HttpExceptionInterface
 {
-    /**
-     * @var array
-     */
-    protected $headers = [];
-
-    /**
-     * @var string
-     */
-    protected $message;
-
-    /**
-     * @var integer
-     */
-    protected $status;
-
     public function __construct(
-        int $status,
-        string $message = null,
+        protected int $status,
+        protected $message = null,
         \Exception $previous = null,
-        array $headers = [],
+        protected array $headers = [],
         int $code = 0
     ) {
-        $this->headers = $headers;
-        $this->message = $message;
-        $this->status  = $status;
-
         parent::__construct($message, $code, $previous);
     }
 
@@ -61,7 +42,7 @@ class Exception extends \Exception implements HttpExceptionInterface
             $response->getBody()->write(json_encode([
                 'status_code'   => $this->status,
                 'reason_phrase' => $this->message
-            ]));
+            ], JSON_THROW_ON_ERROR));
         }
 
         return $response->withStatus($this->status, $this->message);

--- a/src/Http/Response/Decorator/DefaultHeaderDecorator.php
+++ b/src/Http/Response/Decorator/DefaultHeaderDecorator.php
@@ -8,10 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class DefaultHeaderDecorator
 {
-    /**
-     * @var array
-     */
-    protected $headers = [];
+    protected array $headers = [];
 
     public function __construct(array $headers = [])
     {

--- a/src/Middleware/MiddlewareAwareTrait.php
+++ b/src/Middleware/MiddlewareAwareTrait.php
@@ -11,10 +11,7 @@ use Psr\Http\Server\MiddlewareInterface;
 
 trait MiddlewareAwareTrait
 {
-    /**
-     * @var array
-     */
-    protected $middleware = [];
+    protected array $middleware = [];
 
     public function getMiddlewareStack(): iterable
     {

--- a/src/Route.php
+++ b/src/Route.php
@@ -26,7 +26,7 @@ class Route implements
      */
     protected $handler;
 
-    protected RouteGroup $group;
+    protected ?RouteGroup $group = null;
 
     protected array $vars = [];
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -26,30 +26,12 @@ class Route implements
      */
     protected $handler;
 
-    /**
-     * @var RouteGroup
-     */
-    protected $group;
+    protected RouteGroup $group;
 
-    /**
-     * @var string
-     */
-    protected $method;
+    protected array $vars = [];
 
-    /**
-     * @var string
-     */
-    protected $path;
-
-    /**
-     * @var array
-     */
-    protected $vars = [];
-
-    public function __construct(string $method, string $path, $handler)
+    public function __construct(protected string $method, protected string $path, $handler)
     {
-        $this->method  = $method;
-        $this->path    = $path;
         $this->handler = $handler;
     }
 
@@ -57,7 +39,7 @@ class Route implements
     {
         $callable = $this->handler;
 
-        if (is_string($callable) && strpos($callable, '::') !== false) {
+        if (is_string($callable) && str_contains($callable, '::')) {
             $callable = explode('::', $callable);
         }
 

--- a/src/RouteConditionHandlerTrait.php
+++ b/src/RouteConditionHandlerTrait.php
@@ -9,25 +9,13 @@ use RuntimeException;
 
 trait RouteConditionHandlerTrait
 {
-    /**
-     * @var ?string
-     */
-    protected $host;
+    protected ?string $host = null;
 
-    /**
-     * @var ?string
-     */
-    protected $name;
+    protected ?string $name = null;
 
-    /**
-     * @var ?int
-     */
-    protected $port;
+    protected ?int $port = null;
 
-    /**
-     * @var ?string
-     */
-    protected $scheme;
+    protected ?string $scheme = null;
 
     public function getHost(): ?string
     {

--- a/src/RouteGroup.php
+++ b/src/RouteGroup.php
@@ -23,20 +23,11 @@ class RouteGroup implements
      */
     protected $callback;
 
-    /**
-     * @var RouteCollectionInterface
-     */
-    protected $collection;
+    protected string $prefix;
 
-    /**
-     * @var string
-     */
-    protected $prefix;
-
-    public function __construct(string $prefix, callable $callback, RouteCollectionInterface $collection)
+    public function __construct(string $prefix, callable $callback, protected RouteCollectionInterface $collection)
     {
         $this->callback   = $callback;
-        $this->collection = $collection;
         $this->prefix     = sprintf('/%s', ltrim($prefix, '/'));
     }
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -29,17 +29,14 @@ class Router implements
     /**
      * @var RouteGroup[]
      */
-    protected $groups = [];
+    protected array $groups = [];
 
     /**
      * @var Route[]
      */
-    protected $namedRoutes = [];
+    protected array $namedRoutes = [];
 
-    /**
-     * @var array
-     */
-    protected $patternMatchers = [
+    protected array $patternMatchers = [
         '/{(.+?):number}/'        => '{$1:[0-9]+}',
         '/{(.+?):word}/'          => '{$1:[a-zA-Z]+}',
         '/{(.+?):alphanum_dash}/' => '{$1:[a-zA-Z0-9-_]+}',
@@ -48,31 +45,19 @@ class Router implements
     ];
 
     /**
-     * @var RouteCollector
-     */
-    protected $routeCollector;
-
-    /**
      * @var Route[]
      */
-    protected $routes = [];
+    protected array $routes = [];
 
-    /**
-     * @var bool
-     */
-    protected $routesPrepared = false;
+    protected bool $routesPrepared = false;
 
-    /**
-     * @var array
-     */
-    protected $routesData = [];
+    protected array $routesData = [];
 
-    public function __construct(?RouteCollector $routeCollector = null)
+    public function __construct(protected RouteCollector $routeCollector = new RouteCollector(
+        new RouteParser\Std(),
+        new DataGenerator\GroupCountBased()
+    ))
     {
-        $this->routeCollector = $routeCollector ?? new RouteCollector(
-            new RouteParser\Std(),
-            new DataGenerator\GroupCountBased()
-        );
     }
 
     public function addPatternMatcher(string $alias, string $regex): self
@@ -150,7 +135,7 @@ class Router implements
         $this->processGroups($request);
         $this->buildNameIndex();
 
-        $routes = array_merge(array_values($this->routes), array_values($this->namedRoutes));
+        $routes = [...array_values($this->routes), ...array_values($this->namedRoutes)];
         $options = [];
 
         /** @var Route $route */
@@ -249,7 +234,7 @@ class Router implements
             // route is not matched so exceptions are handled correctly
             if (
                 $group->getStrategy() !== null
-                && strncmp($activePath, $group->getPrefix(), strlen($group->getPrefix())) === 0
+                && str_starts_with($activePath, $group->getPrefix())
             ) {
                 $this->setStrategy($group->getStrategy());
             }

--- a/src/Strategy/AbstractStrategy.php
+++ b/src/Strategy/AbstractStrategy.php
@@ -8,10 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 
 abstract class AbstractStrategy implements StrategyInterface
 {
-    /**
-     * @var array
-     */
-    protected $responseDecorators = [];
+    protected array $responseDecorators = [];
 
     public function addResponseDecorator(callable $decorator): StrategyInterface
     {

--- a/src/Strategy/ApplicationStrategy.php
+++ b/src/Strategy/ApplicationStrategy.php
@@ -53,11 +53,8 @@ class ApplicationStrategy extends AbstractStrategy implements ContainerAwareInte
     {
         return new class ($error) implements MiddlewareInterface
         {
-            protected $error;
-
-            public function __construct(Throwable $error)
+            public function __construct(protected Throwable $error)
             {
-                $this->error = $error;
             }
 
             public function process(

--- a/src/Strategy/StrategyAwareTrait.php
+++ b/src/Strategy/StrategyAwareTrait.php
@@ -6,10 +6,7 @@ namespace League\Route\Strategy;
 
 trait StrategyAwareTrait
 {
-    /**
-     * @var ?StrategyInterface
-     */
-    protected $strategy;
+    protected ?StrategyInterface $strategy = null;
 
     public function setStrategy(StrategyInterface $strategy): StrategyAwareInterface
     {

--- a/tests/DispatchIntegrationTest.php
+++ b/tests/DispatchIntegrationTest.php
@@ -124,7 +124,7 @@ class DispatchIntegrationTest extends TestCase
 
         $router = new Router();
 
-        $router->map('GET', '/example/route', static function () {
+        $router->map('GET', '/example/route', static function (): never {
             throw new Exception();
         });
 
@@ -227,7 +227,7 @@ class DispatchIntegrationTest extends TestCase
         /** @var Router $router */
         $router = (new Router())->setStrategy(new JsonStrategy($factory));
 
-        $router->map('GET', '/example/route', function () {
+        $router->map('GET', '/example/route', function (): never {
             throw new Exception('Blah');
         });
 
@@ -305,7 +305,7 @@ class DispatchIntegrationTest extends TestCase
 
         $router = (new Router())->setStrategy(new JsonStrategy($factory));
 
-        $router->map('GET', '/example/route', static function () {
+        $router->map('GET', '/example/route', static function (): never {
             throw new BadRequestException();
         });
 
@@ -730,9 +730,7 @@ class DispatchIntegrationTest extends TestCase
         /** @var Router $router */
         $router = (new Router())->setStrategy(new Strategy\ApplicationStrategy());
 
-        $router->map('GET', '/', function (): array {
-            return [];
-        })->setStrategy(new JsonStrategy($factory));
+        $router->map('GET', '/', static fn(): array => [])->setStrategy(new JsonStrategy($factory));
         $router->dispatch($request);
     }
 
@@ -777,9 +775,7 @@ class DispatchIntegrationTest extends TestCase
         $router = new Router();
 
         $router->group('/group', function ($r) use ($factory) {
-            $r->get('/id', function (): array {
-                return [];
-            })->setStrategy(new JsonStrategy($factory));
+            $r->get('/id', static fn(): array => [])->setStrategy(new JsonStrategy($factory));
         })->setStrategy(new Strategy\ApplicationStrategy());
 
         $router->dispatch($request);
@@ -789,7 +785,7 @@ class DispatchIntegrationTest extends TestCase
     {
         $counter = new class ()
         {
-            private $counter = 0;
+            private int $counter = 0;
 
             public function getCounter(): int
             {
@@ -907,9 +903,7 @@ class DispatchIntegrationTest extends TestCase
         ;
 
         $router->group('/group', static function ($r) use ($response, $middlewareThree, $middlewareFour): void {
-            $r->get('/route', static function (ServerRequestInterface $request) use ($response): ResponseInterface {
-                return $response;
-            })->middleware($middlewareThree)->lazyMiddlewares([$middlewareFour]);
+            $r->get('/route', static fn(ServerRequestInterface $request): ResponseInterface => $response)->middleware($middlewareThree)->lazyMiddlewares([$middlewareFour]);
         })->middleware($middlewareTwo);
 
         $router->dispatch($request);
@@ -926,30 +920,22 @@ class DispatchIntegrationTest extends TestCase
         $responseTwo->expects(self::once())->method('withHeader')->willReturnSelf();
 
         $routerOne
-            ->get('/', static function (ServerRequestInterface $request) use ($responseOne): ResponseInterface {
-                return $responseOne->withHeader('test', 'test');
-            })
+            ->get('/', static fn(ServerRequestInterface $request): ResponseInterface => $responseOne->withHeader('test', 'test'))
             ->setHost('test1.com')
         ;
 
         $routerOne
-            ->get('/', static function (ServerRequestInterface $request) use ($responseOne): ResponseInterface {
-                return $responseOne->withHeader('test', 'test');
-            })
+            ->get('/', static fn(ServerRequestInterface $request): ResponseInterface => $responseOne->withHeader('test', 'test'))
             ->setHost('test2.com')
         ;
 
         $routerTwo
-            ->get('/', static function (ServerRequestInterface $request) use ($responseTwo): ResponseInterface {
-                return $responseTwo->withHeader('test', 'test');
-            })
+            ->get('/', static fn(ServerRequestInterface $request): ResponseInterface => $responseTwo->withHeader('test', 'test'))
             ->setHost('test1.com')
         ;
 
         $routerTwo
-            ->get('/', static function (ServerRequestInterface $request) use ($responseTwo): ResponseInterface {
-                return $responseTwo->withHeader('test', 'test');
-            })
+            ->get('/', static fn(ServerRequestInterface $request): ResponseInterface => $responseTwo->withHeader('test', 'test'))
             ->setHost('test2.com')
         ;
 

--- a/tests/Http/ExceptionTest.php
+++ b/tests/Http/ExceptionTest.php
@@ -14,7 +14,7 @@ class ExceptionTest extends TestCase
         $json = json_encode([
             'status_code'   => $e->getStatusCode(),
             'reason_phrase' => $e->getMessage()
-        ]);
+        ], JSON_THROW_ON_ERROR);
 
         $body = $this->createMock(StreamInterface::class);
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -60,14 +60,12 @@ class RouterTest extends TestCase
 
     /**
      * Asserts that appropriately configured regex strings are added to patternMatchers.
-     *
-     * @return void
      */
     public function testNewPatternMatchesCanBeAddedAtRuntime(): void
     {
         $router = new class () extends Router
         {
-            public $patternMatchers = [];
+            public array $patternMatchers = [];
         };
 
         $router->addPatternMatcher('mockMatcher', '[a-zA-Z]');

--- a/tests/Strategy/JsonStrategyTest.php
+++ b/tests/Strategy/JsonStrategyTest.php
@@ -139,8 +139,6 @@ class JsonStrategyTest extends TestCase
 
     /**
      * Asserts that the strategy returns the correct middleware to decorate NotFoundException.
-     *
-     * @return void
      */
     public function testStrategyReturnsCorrectNotFoundDecorator(): void
     {


### PR DESCRIPTION
### Problem
As #321 showed, there's an issue to upgrade the `psr/simple-cache` package since it changed its PHP constraint to `>=8.0.0`, and therefore this package's implementation of the `CacheInterface` in [`FileCache`](https://github.com/thephpleague/route/blob/795ad8a005d2bf3951692557b20bbeed5caed013/src/Cache/FileCache.php
) is no longer compatible with `psr/simple-cache` because it's using the new `mixed` type.

### Solution
Drop support for PHP7. It's EOL since end of 11/2022, so now is the time to let it go.

#### NOTE
* This is of course a BC break, so that's why I'm targeting 6.x, but it seems to be behind on 5.x.
* Most changes in this PR have been made by running Rector (and verifying them)