### PR TITLE
Save the matched Route object as an attribute on the request

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -40,7 +40,9 @@ class Dispatcher extends GroupCountBasedDispatcher implements
             case FastRoute::FOUND:
                 $route = $this->ensureHandlerIsRoute($match[1], $method, $uri)->setVars($match[2]);
 
-                if ($this->isExtraConditionMatch($route, $request)) {
+				$request = $request->withAttribute('route', $route);
+
+				if ($this->isExtraConditionMatch($route, $request)) {
                     $this->setFoundMiddleware($route);
                     $request = $this->requestWithRouteAttributes($request, $route);
                     break;

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -40,9 +40,9 @@ class Dispatcher extends GroupCountBasedDispatcher implements
             case FastRoute::FOUND:
                 $route = $this->ensureHandlerIsRoute($match[1], $method, $uri)->setVars($match[2]);
 
-				$request = $request->withAttribute('route', $route);
+                $request = $request->withAttribute('route', $route);
 
-				if ($this->isExtraConditionMatch($route, $request)) {
+                if ($this->isExtraConditionMatch($route, $request)) {
                     $this->setFoundMiddleware($route);
                     $request = $this->requestWithRouteAttributes($request, $route);
                     break;


### PR DESCRIPTION
Could be a solution for https://github.com/thephpleague/route/issues/301, but it is definitely a solution for our use case. We'd like an easy way to read the matched Route during every step of the middleware stack. WDYT?