### PR TITLE
#340 - [4.x] Container resolution error

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -91,11 +91,11 @@ class Route implements
         }
 
         if (is_array($callable) && isset($callable[0]) && is_string($callable[0])) {
-            $callable = [$this->resolveClass($container, $callable[0]), $callable[1]];
+            $callable = [$this->resolveClass($callable[0], $container), $callable[1]];
         }
 
         if (is_string($callable) && method_exists($callable, '__invoke')) {
-            $callable = $this->resolveClass($container, $callable);
+            $callable = $this->resolveClass($callable, $container);
         }
 
         if (! is_callable($callable)) {
@@ -108,12 +108,12 @@ class Route implements
     /**
      * Get an object instance from a class name
      *
-     * @param ContainerInterface|null $container
      * @param string                  $class
+     * @param ContainerInterface|null $container
      *
      * @return object
      */
-    protected function resolveClass(?ContainerInterface $container = null, string $class)
+    protected function resolveClass(string $class, ?ContainerInterface $container = null)
     {
         if ($container instanceof ContainerInterface && $container->has($class)) {
             return $container->get($class);


### PR DESCRIPTION
## Issue
Issue #340 identified an issue in resolving classes in PHP 8. The error is caused by a [breaking change in PHP 8.1](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.optional-before-required) which disallows optional parameters before required parameters.

## Changes
I've reordered the parameter list for `Route::resolveClass` and updated the two locations where it's been called.

## Side Effects
Since this is within `protected` functionality it should only cause an issue for anyone who is customizing the `Route` class.

## Testing
I set up a container with PHP 7.4.33 and ran the existing tests, since the current tests in `RouteTest` already handle Container resolution:
```sh
$ ./vendor/bin/phpcs
............................................... 47 / 47 (100%)


Time: 25ms; Memory: 8MB
```
```sh
$ ./vendor/bin/phpunit
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.33 with Xdebug 3.1.6
Configuration: /workspaces/Route/phpunit.xml

................................................................  64 / 64 (100%)

Time: 187 ms, Memory: 10.00 MB

OK (64 tests, 257 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done
```

For posterity I attempted to test with 8.0+ but there were dependency issues outside the scope of this change.