### PR TITLE
Update psr/http-message to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "nikic/fast-route": "^1.3",
         "psr/container": "^2.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0.1",
+        "psr/http-message": "^1.1|^2.0",
         "psr/http-server-handler": "^1.0.1",
         "psr/http-server-middleware": "^1.0.1",
         "opis/closure": "^3.6.3",


### PR DESCRIPTION
Good job with version 6.0. 

To use this version in modern projects there is still a problem in dependecy to the archaic version of [psr/http-message](https://github.com/php-fig/http-message) 1.0.1 that conflicts with many libraries. 

There should be nothing block from using the newer interfaces from versions 1.1 or 2.0 that add return types.