### PR TITLE
Array typehint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "nikic/fast-route": "^1.3",
         "psr/container": "^2.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0.1",
+        "psr/http-message": "^1.1|^2.0",
         "psr/http-server-handler": "^1.0.1",
         "psr/http-server-middleware": "^1.0.1",
         "opis/closure": "^3.6.3",

--- a/src/Route.php
+++ b/src/Route.php
@@ -25,6 +25,10 @@ class Route implements
 
     protected $handler;
 
+    /**
+     * @param array<string>|string $method
+     * @param array<string> $vars
+     */
     public function __construct(
         protected array|string $method,
         protected string $path,
@@ -66,6 +70,7 @@ class Route implements
         return $callable;
     }
 
+    /** @return array<string>|string */
     public function getMethod(): array|string
     {
         return $this->method;
@@ -87,6 +92,7 @@ class Route implements
         return preg_replace(array_keys($toReplace), array_values($toReplace), $this->path);
     }
 
+    /** @return array<string> */
     public function getVars(): array
     {
         return $this->vars;
@@ -119,6 +125,7 @@ class Route implements
         return $this;
     }
 
+    /** @param array<string> $vars */
     public function setVars(array $vars): self
     {
         $this->vars = $vars;


### PR DESCRIPTION
When implementing my own Strategies, I encounter the problem that parameters and return values of methods returning arrays in Route class do not have typehints. If I use a higher level phpstan in my project this leads to the need to add unnecessary ignors. 

e.g.:

```php
    public function invokeRouteCallable(Route $route, ServerRequestInterface $request): ResponseInterface
    {
        $controller = $route->getCallable($this->getContainer());
        $response = $controller($request, $route->getVars()); //getVars() must be array of strings

        //other code...
    }
```

Just add of `array<string>` solves the problem