### PR TITLE
Reinstate opis/closure v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     ],
     "require": {
         "php": "^8.1",
-        "laravel/serializable-closure": "^2.0.0",
         "nikic/fast-route": "^1.3",
         "psr/container": "^2.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^2.0",
         "psr/http-server-handler": "^1.0.1",
         "psr/http-server-middleware": "^1.0.1",
+        "opis/closure": "^4.0",
         "psr/simple-cache": "^3.0"
     },
     "require-dev": {

--- a/src/Cache/Router.php
+++ b/src/Cache/Router.php
@@ -11,10 +11,11 @@ declare(strict_types=1);
 namespace League\Route\Cache;
 
 use InvalidArgumentException;
-use Laravel\SerializableClosure\SerializableClosure;
 use League\Route\Router as MainRouter;
 use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
 use Psr\SimpleCache\CacheInterface;
+
+use function Opis\Closure\{serialize as s, unserialize as u};
 
 class Router
 {
@@ -31,10 +32,6 @@ class Router
         protected bool $cacheEnabled = true,
         protected string $cacheKey = 'league/route/cache'
     ) {
-        if (true === $this->cacheEnabled && $builder instanceof \Closure) {
-            $builder = new SerializableClosure($builder);
-        }
-
         $this->builder = $builder;
     }
 
@@ -53,7 +50,7 @@ class Router
     protected function buildRouter(ServerRequestInterface $request): MainRouter
     {
         if (true === $this->cacheEnabled && $cache = $this->cache->get($this->cacheKey)) {
-            $router = unserialize($cache, ['allowed_classes' => true]);
+            $router = u($cache, ['allowed_classes' => true]);
 
             if ($router instanceof MainRouter) {
                 return $router;
@@ -61,11 +58,6 @@ class Router
         }
 
         $builder = $this->builder;
-
-        if ($builder instanceof SerializableClosure) {
-            $builder = $builder->getClosure();
-        }
-
         $router = $builder(new MainRouter());
 
         if (false === $this->cacheEnabled) {
@@ -74,7 +66,7 @@ class Router
 
         if ($router instanceof MainRouter) {
             $router->prepareRoutes($request);
-            $this->cache->set($this->cacheKey, serialize($router));
+            $this->cache->set($this->cacheKey, s($router));
             return $router;
         }
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace League\Route;
 
-use Laravel\SerializableClosure\SerializableClosure;
 use League\Route\Middleware\{MiddlewareAwareInterface, MiddlewareAwareTrait};
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -37,20 +36,12 @@ class Route implements
         protected ?RouteGroup $group = null,
         protected array $vars = []
     ) {
-        if ($handler instanceof \Closure) {
-            $handler = new SerializableClosure($handler);
-        }
-
         $this->handler = ($handler instanceof RequestHandlerInterface) ? [$handler, 'handle'] : $handler;
     }
 
     public function getCallable(?ContainerInterface $container = null): callable
     {
         $callable = $this->handler;
-
-        if ($callable instanceof SerializableClosure) {
-            $callable = $callable->getClosure();
-        }
 
         if (is_string($callable) && str_contains($callable, '::')) {
             $callable = explode('::', $callable);


### PR DESCRIPTION
This partially reverts commit 38775ed32d49ff1ce98d88adaa06a8d66b923436.

The switch to laravel/serializable-closure v2 was unnecessary, as opis/closure is indeed maintained, and has recently had a major update to resolve issues with PHP 8.4.

Furthermore, requiring laravel/serializable-closure v2 causes a dependency conflict with php-di/php-di v7, and possibly other packages that are still on laravel/serializable-closure v1.